### PR TITLE
feat: added a sort-atom built in function

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -86,6 +86,8 @@ empty(_) :- fail.
 'first-from-pair'([A, _], A).
 'second-from-pair'([_, A], A).
 'unique-atom'(A, B) :- list_to_set(A, B).
+'sort-atom'(List, Sorted) :-
+    msort(List, Sorted).
 'car-atom'([H|_], H).
 'cdr-atom'([_|T], T).
 decons([H|T], [H|[T]]).
@@ -274,6 +276,6 @@ unregister_fun(N/Arity) :- retractall(fun(N)),
                           'py-call', 'get-type', 'get-metatype', '=alpha', concat, sread, cons, reverse,
                           '#+','#-','#*','#div','#//','#mod','#min','#max','#<','#>','#=','#\\=',
                           'union-atom', 'cons-atom', 'intersection-atom', 'subtraction-atom', 'index-atom', id,
-                          'pow-math', 'sqrt-math', 'abs-math', 'log-math', 'trunc-math', 'ceil-math',
+                          'pow-math', 'sqrt-math','sort-atom','abs-math', 'log-math', 'trunc-math', 'ceil-math',
                           'floor-math', 'round-math', 'sin-math', 'cos-math', 'tan-math', 'asin-math',
                           'acos-math', 'atan-math', 'isnan-math', 'isinf-math', 'min-atom', 'max-atom']).


### PR DESCRIPTION
## Description
This PR adds a new builtin function `sort-atom` that sorts a list of atoms in ascending order.

## Changes
- Added `sort-atom` builtin function in `metta.pl`
- Implemented sorting logic for atom lists

## Example Usage
```pettalang
; Sort a list of atoms
(sort-atom (a c b d))     ; returns (a b c d)
(sort-atom (5 2 9 1))     ; returns (1 2 5 9)
(sort-atom (zebra apple banana)) ; returns (apple banana zebra)
```