### PR TITLE
intersection-atom , size-atom implementation fix

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -272,6 +272,10 @@ unregister_fun(N/Arity) :- retractall(fun(N)),
                           repr, repra, 'println!', 'readln!', 'trace!', test, assert, 'mm2-exec',
                           foldl, append, length, sort, msort, 'is-member', 'exclude-item', list_to_set, maplist, eval, reduce, 'import!',
                           'add-atom', 'remove-atom', 'get-atoms', match, 'is-var', 'is-expr', 'get-mettatype',
-                          decons, 'fold-flat', 'fold-nested', 'map-flat', 'map-nested', union, intersection, subtract,
-                          unify, 'py-call', 'get-type', 'get-metatype', '=alpha','=@=', concat, sread, cons, reverse,
-                          '#+','#-','#*','#div','#//','#mod','#min','#max','#<','#>','#=','#\\=']).
+                          decons, 'decons-atom', 'fold-flat', 'fold-nested', 'map-flat', 'map-nested', union, intersection, subtract,
+                          'py-call', 'get-type', 'get-metatype', '=alpha', concat, sread, cons, reverse,
+                          '#+','#-','#*','#div','#//','#mod','#min','#max','#<','#>','#=','#\\=',
+                          'union-atom', 'cons-atom', 'intersection-atom', 'subtraction-atom', 'index-atom', id,
+                          'pow-math', 'sqrt-math', 'abs-math', 'log-math', 'trunc-math', 'ceil-math',
+                          'floor-math', 'round-math', 'sin-math', 'cos-math', 'tan-math', 'asin-math',
+                          'acos-math', 'atan-math', 'isnan-math', 'isinf-math', 'min-atom', 'max-atom', 'size-atom']).


### PR DESCRIPTION
    
 **Intersection-atom** 

**Issue**: PeTTa's intersection includes the largest frequency of elements in both expressions, while Metta's intersection-atom keeps the smallest.
**Suggestion**: Use select  **select** builtin prolog function in the intersection function definition. This will fix the frequency issue.

  **Size-atom**

 **Issue**: Prolog's length function is used instead of size-atom.
 **Suggestion**: Replace length with a custom size-atom function and register it.
