### PR TITLE
feat: Add time retrieval and formatting utilities

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -153,6 +153,9 @@ assert(Goal, true) :- ( call(Goal) -> true
                                       halt(1) ).
 
 %%
+%%% Time Operations: %%%
+'current-time'(Time) :- get_time(Time).
+'format-time'(Format, TimeString) :- get_time(Time), format_time(atom(TimeString), Format, Time).
 
 %%% Python bindings: %%%
 'py-call'(SpecList, Result) :- 'py-call'(SpecList, Result, []).
@@ -225,4 +228,4 @@ unregister_fun(N/Arity) :- retractall(fun(N)),
                           'pow-math', 'sqrt-math', 'sort-atom','abs-math', 'log-math', 'trunc-math', 'ceil-math',
                           'floor-math', 'round-math', 'sin-math', 'cos-math', 'tan-math', 'asin-math',
                           'acos-math', 'atan-math', 'isnan-math', 'isinf-math', 'min-atom', 'max-atom',
-                          'foldl-atom', 'map-atom', 'filter-atom']).
+                          'foldl-atom', 'map-atom', 'filter-atom','current-time','format-time']).


### PR DESCRIPTION
- current-time: Get current Unix timestamp
- format-time: Format current time as customizable string

```
!(current-time ) ; Unix timestamp like this (1761732083.095938) 
!(format-time "%Y-%m-%d")
("2025-10-29")  ; Current date in YYYY-MM-DD format

!(format-time "%H:%M:%S")  
("14:02:14")    ; Current time in HH:MM:SS format

!(format-time "%Y-%m-%d %H:%M:%S")
("2025-10-29 14:02:14")  ; Full date and time

!(format-time "%A, %B %d, %Y")
("Tuesday, October 29, 2025")  ;Human-readable format
```