### PR TITLE
Update documentation: SWI-Prolog 9.3.x requirement and Jupyter kernel…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ python/__pycache__
 mork_ffi/morklib.so
 mork_ffi/Cargo.lock
 python/tests/__pycache__
+.vscode/

--- a/README.md
+++ b/README.md
@@ -2,12 +2,33 @@
 
 Efficient MeTTa in Prolog.
 
-**Dependencies**
+### Dependencies
 
-SWI-Prolog
+- SWI-Prolog >= 9.3.x
+- Python 3.x (for janus Python interop)
 
-**Usage**
+### Usage
 
 Example run:
 
 `time sh run.sh ./examples/nars_tuffy.metta`
+
+### Jupyter Notebook Support
+
+A Jupyter kernel for PeTTa is available in a separate repository for interactive MeTTa development in notebooks.
+
+**Repository:** [trueagi-io/jupyter-petta-kernel](https://github.com/trueagi-io/jupyter-petta-kernel)
+
+Quick install:
+
+```bash
+# Set PETTA_PATH to this PeTTa installation
+export PETTA_PATH=/path/to/PeTTa
+
+# Clone and install the kernel
+git clone https://github.com/trueagi-io/jupyter-petta-kernel.git
+cd jupyter-petta-kernel
+./install.sh
+```
+
+See the [jupyter-petta-kernel README](https://github.com/trueagi-io/jupyter-petta-kernel/blob/main/README.md) for detailed installation instructions and usage.

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+
 if [ -f $SCRIPT_DIR/mork_ffi/target/release/libmork_ffi.so ]; then
     LD_PRELOAD=$SCRIPT_DIR/mork_ffi/target/release/libmork_ffi.so \
     swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- "$@" mork


### PR DESCRIPTION
## Summary
Updates PeTTa documentation to reflect the minimum SWI-Prolog version requirement and reference the extracted Jupyter kernel repository.

## Changes

### README.md
- Updated dependencies to specify `SWI-Prolog >= 9.3.x` (previously unversioned)
- Added `Python 3.x` dependency note (for janus Python interop)
- Added Jupyter Notebook Support section with link to [jupyter-petta-kernel](https://github.com/trueagi-io/jupyter-petta-kernel)

### .gitignore
- Added `.vscode/` directory

### run.sh
- Minor formatting (added blank line for readability)

## Background

The Jupyter kernel has been extracted to a standalone repository for easier maintenance and distribution. This PR updates the README to point users to the new location.