### PR TITLE
replace numbervars with var string

### DIFF
--- a/examples/specialize.metta
+++ b/examples/specialize.metta
@@ -42,3 +42,11 @@
         (fold-nested $f ($f $init $x) $xs)))
 
 !(test (fold-nested + 0 (1 (2 3))) 6)
+
+(= (higher-order-fun $a $b) (($a 1) ($b 1)))
+
+(= (fun2) (higher-order-fun (+ 1) (* 1)))
+(= (fun3) (higher-order-fun (* 1) (+ 1)))
+
+!(test (fun2) (2 1))
+!(test (fun3) (1 2))

--- a/src/specializer.pl
+++ b/src/specializer.pl
@@ -17,7 +17,7 @@ specialize_call(HV, AVs, Out, Goal) :- %1.  Skip specialization when HV is the f
                                        catch(nb_getval(HV, MetaList0), _, fail),
                                        copy_term(MetaList0, MetaList),
                                        %3. Copy all clause variables eligible for specialization across all meta-clauses:
-                                       setof(HoVar, ArgsNorm^BodyExpr^HoBinds^HoBindsPerArg^
+                                       bagof(HoVar, ArgsNorm^BodyExpr^HoBinds^HoBindsPerArg^
                                                     ( member(fun_meta(ArgsNorm, BodyExpr), MetaList),
                                                       maplist(specializable_vars(BodyExpr), AVs, ArgsNorm, HoBinds),
                                                       member(HoBindsPerArg, HoBinds),


### PR DESCRIPTION
```
!(import! &self (library lib_roman))

(= (in_map $kb $elem) (: $kb $prf $elem $tv))

(= (inTemplate $kb $tail)
 (let $res (map-flat (in_map $kb) $tail)
      ($kb)))
```

The above fails to compile without this change.