### PR TITLE
Update lib imports and roman tuple helpers

### DIFF
--- a/lib/lib_import.metta
+++ b/lib/lib_import.metta
@@ -12,4 +12,4 @@
                                                                              ($function (superpose $importfunctions)))
                                                                             (import_prolog_function $function)))
 
-!(import_prolog_functions_from_file (library lib_import.pl) (static-import! git-import!))
+!(import_prolog_functions_from_file (library lib_import.pl) (static-import! git-import! use-module!))

--- a/lib/lib_import.pl
+++ b/lib/lib_import.pl
@@ -46,6 +46,9 @@ replace_all(P, R, S, O) :- split_string(S, P, "", Parts),
                                             qcompile(PlFile),
                                             consult(QlfFile) ).
 
+
+'use-module!'(Module, true) :- use_module(library(Module)).
+
 %%% Git Import: %%%
 'git-import!'(GitPath, true) :- 'git-import!'(GitPath, '', './repos', true).
      

--- a/lib/lib_roman.metta
+++ b/lib/lib_roman.metta
@@ -84,5 +84,8 @@
 
 ;Utils
 
+(= (fst ($a $b)) $a)
+(= (snd ($a $b)) $b)
+
 ;(= (prog1 (cons $x $xs)) $x)
 ;(= (progn (rcons $xs $x)) $x)


### PR DESCRIPTION
## Summary
- expose `use-module!` through `lib/lib_import.metta` and implement it in `lib/lib_import.pl` so metta code can load SWI libraries.
- add `fst` and `snd` helpers to `lib/lib_roman.metta` to support tuple-style access used by library code.
- include only remaining `lib/` updates from the previous working tree cleanup (no `src/` or artifact changes).