### PR TITLE
Refactor == operator to support generic numeric equality

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -38,12 +38,11 @@ parse(Str, R) :- sread(Str, R).
 '%'(A,B,R)  :- R is A mod B.
 '<'(A,B,R)  :- (A<B -> R=true ; R=false).
 '>'(A,B,R)  :- (A>B -> R=true ; R=false).
-'=='(A,B,R) :-
+'=='(A,B,true) :-
     ( A == B
     ; (number(A), number(B), A =:= B)
     ),
-    !,
-    R = true.
+    !.
 '=='(_,_,false).
 '!='(A,B,R) :- (A==B -> R=false ; R=true).
 '='(A,B,R) :-  (A=B -> R=true ; R=false).


### PR DESCRIPTION

## Summary

This update refactors `'=='/3` to avoid any recursive structural equality checks and instead rely entirely on Prolog’s built-in optimized operators.

The implementation:

* Uses strict term equality (`==/2`) as the primary fast path
* Falls back to arithmetic equality (`=:=/2`) when both arguments are numbers
* Introduces no recursive traversal
* Preserves performance by leveraging built-in predicates only

This approach removes the performance concerns associated with recursive equality checking while maintaining clear and predictable semantics. Since no custom recursion is introduced, the change should not raise the benchmarking issues previously mentioned.

Feedback and suggestions are welcome.