### PR TITLE
fix(parser): resolve infinite hang on trailing semicolon comments at EOF

### DIFF
--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -74,5 +74,5 @@ strip([], _, []).
 strip([0'"|R], 0, [0'"|O]) :- !, strip(R, 1, O).
 strip([0'"|R], 1, [0'"|O]) :- !, strip(R, 0, O).
 strip([0'\n|R], In, [0'\n|O]) :- !, strip(R, In, O).
-strip([0';|R], 0, Out) :- !, append(_, [0'\n|Rest], R), strip(Rest, 0, Out).
+strip([0';|R], 0, Out) :- !, (append(_, [0'\n|Rest], R) -> strip(Rest, 0, Out) ; Out = []).
 strip([C|R], In, [C|O]) :- strip(R, In, O).


### PR DESCRIPTION
# Overview

This PR is intended to resolve a critical parsing failure and infinite hang in the `src/filereader.pl` module. It ensures that MeTTa comments (`;`) located at the absolute End-of-File (EOF) are handled gracefully, preventing the transpiler from stalling in WSL/Linux environments when a trailing newline is missing.

# Changes

**`src/filereader.pl`:**

* Updated the `strip/3` predicate to handle comments that are not terminated by a newline.
* Implemented a conditional check (`-> ;`) to detect the End-of-File.
* Resolved a bug where `append/3` would fail if `0'\n` was missing, which previously caused the entire file-loading process to hang or return empty results.

# Usage

You can now safely include comments at the very end of your `.metta` files without requiring a trailing empty line:

```metta
; This code will now execute perfectly even if the file ends exactly here
(= (add10 $x) (+ $x 10))
!(add10 5) ;
```

---

# Updated `strip` Predicate in `src/filereader.pl`

```prolog
% Optimized comment stripping logic to support EOF termination
strip([0';|R], 0, Out) :- !,
                            ( append(_, [0'\n|Rest], R) ->
                                strip(Rest, 0, Out)
                            ; Out = []
                            ).
```

---

# Technical Breakdown

* **EOF Fallback:** If `append/3` fails to find a newline, the `Out = []` branch triggers. This successfully closes the code-stripping recursion instead of failing the predicate.
* **WSL/Shell Compatibility:** By ensuring the predicate always returns a result (success), the Prolog engine can finish the goal and release the terminal, fixing the "infinite hang" issue.
