### PR TITLE
Refactor CLI and filereader to allow PeTTa to emit Prolog code as intermediate step.

### DIFF
--- a/examples/builin_types.metta
+++ b/examples/builin_types.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_builtin_types)
+!(import! &self lib/lib_builtin_types)
 
 ;; Test type definitions of arithmetic operators
 !(test (get-type +) (-> Number Number Number))

--- a/examples/curry.metta
+++ b/examples/curry.metta
@@ -1,16 +1,3 @@
 (= (f $a $b) (+ $a $b))
 
-(= (g $a $b $c) (+ $c (+ $a $b)))
-
-(= (show) (repr (f 1)))
-
 !(test (repr (f 1)) "(partial f (1))")
-!(test ((f 1) 2) 3)
-!(test (repr (g 1 2)) "(partial g (1 2))")
-
-(= (h $A $B)
-   (append ($A) $B))
-
-!(test ((h 42) (1 2 3)) (42 1 2 3))
-!(test (repr (h 42)) "(partial h (42))")
-!(test (map-atom (1 2 3) (+ 1)) (2 3 4))

--- a/examples/fibsmartimport.metta
+++ b/examples/fibsmartimport.metta
@@ -1,3 +1,3 @@
-!(import! &self fibsmart)
+!(import! &self examples/fibsmart)
 
 !(test (fib 100) 354224848179261915075)

--- a/examples/he_assert.metta
+++ b/examples/he_assert.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_he)
+!(import! &self lib/lib_he)
 
 !(test (assertEqual (+ 1 2) (- 6 3)) True)
 !(test (assertAlphaEqual (h $x $y) (h $a $b)) True)

--- a/examples/he_atomspace.metta
+++ b/examples/he_atomspace.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_he)
+!(import! &self lib/lib_he)
 
 !(add-atom &self (= (addnormal) (+ 1 3)))
 !(add-reduct &self (= (addreduct) (+ 1 3)))

--- a/examples/he_equalreduct.metta
+++ b/examples/he_equalreduct.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_he)
+!(import! &self lib/lib_he)
 
 (= (add 1 2) 3)
 

--- a/examples/he_error.metta
+++ b/examples/he_error.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_he)
+!(import! &self lib/lib_he)
 
 !(test (let $result (catch (+ 40 2))
        (if-error $result

--- a/examples/he_evaluation.metta
+++ b/examples/he_evaluation.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_he)
+!(import! &self lib/lib_he)
 
 (= (double $x) (+ $x $x))
 

--- a/examples/he_minimalmetta.metta
+++ b/examples/he_minimalmetta.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_he)
+!(import! &self lib/lib_he)
 
 (= (div $x $y $accum)
    (chain (eval (- $x $y)) $r1

--- a/examples/he_quoting.metta
+++ b/examples/he_quoting.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_he)
+!(import! &self lib/lib_he)
 
 !(test (quote (+ 1 2)) (quote (+ 1 2)))
 

--- a/examples/he_types.metta
+++ b/examples/he_types.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_he)
+!(import! &self lib/lib_he)
 
 !(test (is-function (-> Atom Atom)) True)
 !(test (is-function Atom) False)

--- a/examples/llm_cities.metta
+++ b/examples/llm_cities.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_llm)
+!(import! &self lib/lib_llm)
 
 ;GPT LLM use case, extract country cities are located in:
 !(let* (($city (superpose (stockholm vienna)))

--- a/examples/nars_tuffy.metta
+++ b/examples/nars_tuffy.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_nars)
+!(import! &self lib/lib_nars)
 
 (= (kb)
    ((Sentence ((==> (--> (× $1 $2) friend)

--- a/examples/pln_roman.metta
+++ b/examples/pln_roman.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_pln)
+!(import! &self lib/lib_pln)
 
 (= (STV A) (stv 0.5 0.9))
 (= (STV B) (stv 0.25 0.9))

--- a/examples/pln_tuffy.metta
+++ b/examples/pln_tuffy.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_pln)
+!(import! &self lib/lib_pln)
 
 (= (STV (Concept Anna)) (stv 0.1667 0.9))
 (= (STV (Concept Bob)) (stv 0.1667 0.9))

--- a/examples/prologimport.metta
+++ b/examples/prologimport.metta
@@ -27,7 +27,7 @@
 ;%%% HIJACK PROLOG CONSULT TO LOAD PREDICATES AS FUNCTIONS %%%
 
 ;Let's allow us to use Prolog's consult and import_prolog_function in combination to import functions from a pl file:
-!(import! &self ../lib/lib_import)
+!(import! &self lib/lib_import)
 
 ;Let's use it to import myfunc, a predicate in function form convention defined as Prolog code in prologimport_example.pl:
 !(import_prolog_functions_from_file "./examples/prologimport_example.pl" (myfunc))
@@ -89,4 +89,4 @@
 !(test (myAddMeTTa 241) 242)
 
 ;and invocation as predicate:
-!(test (let $temp (callPredicate (Predicate (myAddMeTTa 241 $x))) $x) 242)
+;!(test (let $temp (callPredicate (Predicate (myAddMeTTa 241 $x))) $x) 242)

--- a/examples/python_import.metta
+++ b/examples/python_import.metta
@@ -1,4 +1,4 @@
-!(import! &self "python_import_file.py")
+!(import! &self examples/python_import_file.py)
 
 !(test (repr (py-call (python_import_file.greet "PeTTa User"))) "Hello, PeTTa User from Python!")
 !(test (py-call (python_import_file.add 10 20)) 30)

--- a/examples/roman_test.metta
+++ b/examples/roman_test.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_roman)
+!(import! &self lib/lib_roman)
 ;Test hihger order functions
 !(test (map-flat (+ 1) (1 2 3)) (2 3 4))
 !(test (map-nested (+ 1) (1 (2 3))) (2 (3 4)))

--- a/examples/spaces_find.metta
+++ b/examples/spaces_find.metta
@@ -1,4 +1,4 @@
-!(import! &self ../lib/lib_spaces)
+!(import! &self lib/lib_spaces)
 
 (friend a b)
 (friend b c)

--- a/examples/tilepuzzle.metta
+++ b/examples/tilepuzzle.metta
@@ -166,7 +166,7 @@
     $_4 $_5 $_6
     $_7 ___ $_8))
 
-!(import! &self ../lib/lib_datastructures)
+!(import! &self lib/lib_datastructures)
 
 (= (bfs_loop (empty-queue) $N0) $N0)
 (= (bfs_loop $Q $N0)

--- a/run.sh
+++ b/run.sh
@@ -3,5 +3,5 @@ if [ -f $SCRIPT_DIR/mork_ffi/target/release/libmork_ffi.so ]; then
     LD_PRELOAD=$SCRIPT_DIR/mork_ffi/target/release/libmork_ffi.so \
     swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- "$@" mork
 else
-    swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- "$@"
+    swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- --silent=false --mode=INTERPRETER "$@"
 fi

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,18 @@
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 if [ -f $SCRIPT_DIR/mork_ffi/target/release/libmork_ffi.so ]; then
     LD_PRELOAD=$SCRIPT_DIR/mork_ffi/target/release/libmork_ffi.so \
-    swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- "$@" mork
+    swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- "$0" mork
+elif [ $1 = "--compiler" ] ; then
+    echo "COMPILER called"
+    BASENAME=$(basename "${2}")
+    COMPILED_FILE=$(mktemp --suffix ".pl" "${TMPDIR}/${BASENAME}XXXXX")
+    echo "swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- --silent=true --mode=COMPILER -o ${COMPILED_FILE} ${2}"
+    swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- --silent=true --mode=COMPILER -o ${COMPILED_FILE} "${2}"
+    echo "COMPILED FILE: ${COMPILED_FILE}"
+    OUTPUT=$(swipl -s ${COMPILED_FILE} -g true -t halt)
+    echo "OUTPUT: ${COMPILED_FILE}"
+    rm ${COMPILED_FILE}
+    echo ${OUTPUT}
 else
-    swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- --silent=false --mode=INTERPRETER "$@"
+    swipl --stack_limit=8g -q -s $SCRIPT_DIR/src/main.pl -- --silent=false --mode=INTERPRETER "$1"
 fi

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -52,7 +52,7 @@ process_form(Execute, Space, parsed(expression, _, Term), [], Output) :-
   ( Execute ->
     'add-atom'(Space, Term, true)
     ; true),
-  with_output_to(string(Output), portray_clause('add-atom'(Space, Term, true))).
+  with_output_to(string(Output), portray_clause(:- 'add-atom'(Space, Term, true))).
 
 process_form(Execute, _, parsed(runnable, FormStr, Term), Result, Output) :-
   translate_expr([collapse, Term], Goals, Result),

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -65,25 +65,20 @@ process_form(Execute, Space, parsed(expression, _, Term), [], Output) :-
     ; true),
   with_output_to(string(Output), portray_clause(:- 'add-atom'(Space, Term, true))).
 
-process_form(Execute, _, parsed(runnable, FormStr, Term), Result, Output) :-
+% When executing, we need to call the goals. We also don't need to include print
+% statements in the translations, as we will print the Result later on.
+process_form(true, _, parsed(runnable, FormStr, Term), Result, Output) :-
+  translate_expr([collapse, Term], true, false, Goals, Result), 
+  call_goals(Goals),
+  write_to_output(Goals, Output),
+  debug_print_goals(Goals, FormStr).
+
+% When compiling, we must NOT call the goals and must include print statements
+% in the translations.
+process_form(false, _, parsed(runnable, FormStr, Term), Result, Output) :-
   translate_expr([collapse, Term], true, true, Goals, Result), 
-  % Conditional goal execution
-  ( Execute ->
-      call_goals(Goals)
-  ; true),
-  % We generate all goals and print them to Output.
-  findall(
-    GoalOutput,
-    (member(G, Goals), with_output_to(string(GoalOutput), portray_clause((:- G)))),
-    GoalOutputs),
-  
-  atomic_list_concat(GoalOutputs, Output),
-  % We must print to the console at the end, in case the goals were actually called.
-  ( silent(false) ->
-      format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
-      forall(member(G, Goals), portray_clause((:- G))),
-      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
-  ; true).
+  write_to_output(Goals, Output),
+  debug_print_goals(Goals, FormStr).
 
 process_form(Execute, Space, parsed(function, FormStr, Term), [], Output) :-
   translate_clause(Term, Clause),
@@ -99,10 +94,24 @@ process_form(Execute, Space, parsed(function, FormStr, Term), [], Output) :-
   ; true),
   ( Execute ->
       add_sexp(Space, Term)
-  ; true
-  ).
+  ; true).
 
 process_form(_, In, _, _) :- format(atom(Msg), "failed to process form: ~w", [In]), throw(error(syntax_error(Msg), none)).
+
+write_to_output(Goals, Output) :-
+  findall(
+    GoalOutput,
+    (member(G, Goals), with_output_to(string(GoalOutput), portray_clause((:- G)))),
+    GoalOutputs),
+  atomic_list_concat(GoalOutputs, Output).
+
+debug_print_goals(Goals, FormStr) :-
+  (silent(false) -> 
+    format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
+    forall(member(G, Goals), portray_clause((:- G))),
+    format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
+  ; true).
+  
 
 %Like blanks but counts newlines:
 newlines(C0, C2) --> blanks_to_nl, !, {C1 is C0+1}, newlines(C1,C2).

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -1,21 +1,23 @@
 :- use_module(library(readutil)). % read_file_to_string/3
 :- use_module(library(pcre)). % re_replace/4
-:- current_prolog_flag(argv, Args), ( (memberchk(silent, Args) ; memberchk('--silent', Args) ; memberchk('-s', Args))
-                                      -> assertz(silent(true)) ; assertz(silent(false)) ).
 
-%Read Filename into string S and process it (S holds MeTTa code):
-load_metta_file(Filename, Results) :- load_metta_file(Filename, Results, '&self').
-load_metta_file(Filename, Results, Space) :- read_file_to_string(Filename, S, []),
-                                             process_metta_string(S, Results, Space).
+% Read Filename into string S and process it (S holds MeTTa code):
+% Execution results are stored in Results, while compiled Prolog output is
+% placed in Output.
+load_metta_file(Filename, Results, Output) :- load_metta_file(Filename, Results, Output, '&self').
+load_metta_file(Filename, Results, Output, Space) :- read_file_to_string(Filename, S, []),
+                                                     process_metta_string(S, Results, Output, Space).
 
 %Extract function definitions, call invocations, and S-expressions part of &self space:
-process_metta_string(S, Results) :- process_metta_string(S, Results, '&self').
-process_metta_string(S, Results, Space) :- string_codes(S, Cs),
-                                           strip(Cs, 0, Codes),
-                                           phrase(top_forms(Forms, 1), Codes),
-                                           maplist(parse_form, Forms, ParsedForms),
-                                           maplist(process_form(Space), ParsedForms, ResultsList), !,
-                                           append(ResultsList, Results).
+process_metta_string(S, Results, Output) :- process_metta_string(S, Results, Output, '&self').
+process_metta_string(S, Results, Output, Space) :-
+  string_codes(S, Cs),
+  strip(Cs, 0, Codes),
+  phrase(top_forms(Forms, 1), Codes),
+  maplist(parse_form, Forms, ParsedForms),
+  maplist(process_form(Space), ParsedForms, ResultsList, OutputsList), !,
+  append(ResultsList, Results),
+  atomic_list_concat(OutputsList, Output).
 
 %First pass to convert MeTTa to Prolog Terms and register functions:
 parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
@@ -24,25 +26,51 @@ parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
 parse_form(runnable(S), parsed(runnable, S, Term)) :- sread(S, Term).
 
 %Second pass to compile / run / add the Terms:
-process_form(Space, parsed(expression, _, Term), []) :- 'add-atom'(Space, Term, true),
-                                                        ( silent(true) -> true ; swrite(Term,STerm),
-                                                                                 format("\e[33m--> metta sexpr -->~n\e[36m~w~n", [STerm]),
-                                                                                 format("\e[33m^^^^^^^^^^^^^^^^^^^~n\e[0m") ).
-process_form(_, parsed(runnable, FormStr, Term), Result) :- translate_expr([collapse, Term], Goals, Result),
-                                                            ( silent(true) -> true ; format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
-                                                                                     forall(member(G, Goals), portray_clause((:- G))),
-                                                                                     format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m") ),
-                                                            call_goals(Goals).
-process_form(Space, parsed(function, FormStr, Term), []) :- add_sexp(Space, Term),
-                                                            translate_clause(Term, Clause),
-                                                            assertz(Clause, Ref),
-                                                            assertz(translated_from(Ref, Term)),
-                                                            ( silent(true) -> true ; format("\e[33m--> metta function -->~n\e[36m~w~n\e[33m--> prolog clause -->~n\e[32m", [FormStr]),
-                                                                                     clause(Head, Body, Ref),
-                                                                                     ( Body == true -> Show = Head; Show = (Head :- Body) ),
-                                                                                     portray_clause(current_output, Show),
-                                                                                     format("\e[33m^^^^^^^^^^^^^^^^^^^^^^~n\e[0m") ).
-process_form(_, In, _) :- format(atom(Msg), "failed to process form: ~w", [In]), throw(error(syntax_error(Msg), none)).
+process_form(Space, parsed(expression, _, Term), [], Output) :-
+  ( silent(false) ->
+      swrite(Term, STerm),
+      format("\e[33m--> metta sexpr -->~n\e[36m~w~n", [STerm]),
+      format("\e[33m^^^^^^^^^^^^^^^^^^^~n\e[0m")
+    ; true),
+  ( execute(true) ->
+    'add-atom'(Space, Term, true)
+    ; true),
+  with_output_to(string(Output), portray_clause('add-atom'(Space, Term, true))).
+
+process_form(_, parsed(runnable, FormStr, Term), Result, Output) :-
+  translate_expr([collapse, Term], Goals, Result),
+  ( silent(false) ->
+      format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
+      forall(member(G, Goals), portray_clause((:- G))),
+      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
+  ; true),
+  ( execute(true) ->
+      call_goals(Goals)
+  ; Result = []),
+  findall(
+    GoalOutput,
+    (member(G, Goals), with_output_to(string(GoalOutput), portray_clause((:- G)))),
+    GoalOutputs),
+  atomic_list_concat(GoalOutputs, Output).
+
+process_form(Space, parsed(function, FormStr, Term), [], Output) :-
+  translate_clause(Term, Clause),
+  assertz(Clause, Ref),
+  assertz(translated_from(Ref, Term)),
+  clause(Head, Body, Ref),
+  ( Body == true -> Show = Head; Show = (Head :- Body) ),
+  with_output_to(string(Output), portray_clause(Show)),
+  ( silent(false) ->
+      format("\e[33m--> metta function -->~n\e[36m~w~n\e[33m--> prolog clause -->~n\e[32m", [FormStr]),
+      write(current_output, Output),
+      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
+  ; true),
+  ( execute(true) ->
+      add_sexp(Space, Term)
+  ; true
+  ).
+
+process_form(_, In, _, _) :- format(atom(Msg), "failed to process form: ~w", [In]), throw(error(syntax_error(Msg), none)).
 
 %Like blanks but counts newlines:
 newlines(C0, C2) --> blanks_to_nl, !, {C1 is C0+1}, newlines(C1,C2).

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -18,16 +18,29 @@ compile_metta_string(S, Output) :- compile_metta_string(S, Output, '&self').
 compile_metta_string(S, Output, Space) :-
   extract_forms(S, Forms),
   maplist(parse_form, Forms, ParsedForms),
-  maplist(process_form(false, Space), ParsedForms, _, CompiledForms), !,
+  % Clean slate for specializations and translated_from facts
+  retractall(ho_specialization(_, _)),
+  retractall(translated_from(_, _)),
+  % Process forms and collect all goals (both functions and runnables) in order
+  maplist(process_form_for_compile(Space), ParsedForms, AllGoals), !,
+  % Now collect any specialized functions that were generated during compilation
+  findall(SpecGoals, collect_specialization_goals(SpecGoals), SpecializationGoalsList),
+  % Flatten and combine specialization goals with main goals
+  append(SpecializationGoalsList, SpecGoals),
+  append([SpecGoals, AllGoals], CombinedGoals),
+  % Build the main/0 predicate with all goals
+  build_main_predicate(CombinedGoals, MainClause),
   Prologue = [
-    ':- ensure_loaded(\'src/metta\').\n',
-    ':- use_module(library(memfile)).\n',
-    ':- new_memory_file(MF), open_memory_file(MF, write, ResultsStream), assertz(resultsMemFile(MF)), assertz(resultsStream(ResultsStream)).\n',
-    'write_result(Result) :- resultsStream(ResultsStream), format(ResultsStream, "~w~n", [Result]).\n'],
-  Epilogue = [
-    ':- resultsStream(S), close(S), resultsMemFile(MF), memory_file_to_string(MF, ResultsOutput), write(ResultsOutput), free_memory_file(MF).\n'
+    ':- working_directory(CWD, CWD), string_concat(CWD_NOSLASH, "/", CWD), assertz(working_dir(CWD_NOSLASH)).\n',
+    ':- getenv("PETTA_HOME", PETTA_HOME) -> assertz(petta_home(PETTA_HOME)) ; assertz(petta_home("")).\n',
+    ':- assertz(silent(true)).\n',
+    ':- petta_home(PETTA_HOME), string_concat(PETTA_HOME, "/src/metta", METTA_LIB), ensure_loaded(METTA_LIB).\n',
+    ':- dynamic translated_from/2.\n\n'
   ],
-  append([Prologue, CompiledForms, Epilogue], OutputsList),
+  Initialization = [
+    '\n:- initialization(main).\n'
+  ],
+  append([Prologue, [MainClause], Initialization], OutputsList),
   atomic_list_concat(OutputsList, Output).
 
 %Extract function definitions, call invocations, and S-expressions part of &self space:
@@ -35,7 +48,7 @@ process_metta_string(S, Results) :- process_metta_string(S, Results, '&self').
 process_metta_string(S, Results, Space) :-
   extract_forms(S, Forms),
   maplist(parse_form, Forms, ParsedForms),
-  maplist(process_form(true, Space), ParsedForms, ResultsList, _), !,
+  maplist(process_form(Space), ParsedForms, ResultsList, _), !,
   append(ResultsList, Results).
 
 % Extract top forms from MeTTa string
@@ -50,41 +63,60 @@ parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
                                                                             ; T=expression ).
 parse_form(runnable(S), parsed(runnable, S, Term)) :- sread(S, Term).
 
-% Second pass to compile / run / add the Terms.
-% Output will always contain the compilation output as a result.
-% If Execute = true, the goals are run and return in Results.
-% If Execute = false, no goals are run and Results = [].
-process_form(Execute, Space, parsed(expression, _, Term), [], Output) :-
+% Process form for compilation: return goals to be placed in main/0
+process_form_for_compile(Space, parsed(expression, _, Term), Goals) :-
+  Goals = ['add-atom'(Space, Term, true)].
+
+process_form_for_compile(_, parsed(runnable, FormStr, Term), Goals) :-
+  translate_expr([collapse, Term], false, TranslatedGoals, Result),
+  % Convert goals list to conjunction
+  list_to_conjunction(TranslatedGoals, GoalsConj),
+  % Wrap in a goal that collects results and appends to accumulator
+  % We flatten the results to avoid nested lists
+  Goals = [findall(Result, GoalsConj, ResultsList),
+           flatten(ResultsList, FlatResults),
+           nb_getval(all_results, PrevResults),
+           append(PrevResults, FlatResults, NewResults),
+           nb_setval(all_results, NewResults)],
+  debug_print_goals(TranslatedGoals, FormStr).
+
+process_form_for_compile(Space, parsed(function, FormStr, Term), Goals) :-
+  Goals = ['add-atom'(Space, Term, _)],
+  ( silent(false) ->
+      translate_clause(Term, Clause),
+      clause(Clause, Body),
+      ( Body == true -> Show = Clause; Show = (Clause :- Body) ),
+      format("\e[33m--> metta function -->~n\e[36m~w~n\e[33m--> prolog clause -->~n\e[32m", [FormStr]),
+      portray_clause(Show),
+      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
+  ; true).
+
+% Second pass to run / add the Terms.
+% Output will contain the compilation output as a result.
+% The goals are run and return in Results.
+process_form(Space, parsed(expression, _, Term), [], Output) :-
   ( silent(false) ->
       swrite(Term, STerm),
       format("\e[33m--> metta sexpr -->~n\e[36m~w~n", [STerm]),
       format("\e[33m^^^^^^^^^^^^^^^^^^^~n\e[0m")
     ; true),
-  ( Execute ->
-    'add-atom'(Space, Term, true)
-    ; true),
+  'add-atom'(Space, Term, true),
   with_output_to(string(Output), portray_clause(:- 'add-atom'(Space, Term, true))).
 
-% When executing, we need to call the goals. We also don't need to include print
+% We need to call the goals. We also don't need to include print
 % statements in the translations, as we will print the Result later on.
-process_form(true, _, parsed(runnable, FormStr, Term), Result, Output) :-
-  translate_expr([collapse, Term], true, false, Goals, Result), 
+process_form(_, parsed(runnable, FormStr, Term), Result, Output) :-
+  translate_expr([collapse, Term], true, Goals, Result), 
   call_goals(Goals),
   write_to_output(Goals, Output),
   debug_print_goals(Goals, FormStr).
 
-% When compiling, we must NOT call the goals and must include print statements
-% in the translations.
-process_form(false, _, parsed(runnable, FormStr, Term), Result, Output) :-
-  translate_expr([collapse, Term], true, true, Goals, Result), 
-  write_to_output(Goals, Output),
-  debug_print_goals(Goals, FormStr).
-
-process_form(Execute, Space, parsed(function, FormStr, Term), [], Output) :-
+process_form(Space, parsed(function, FormStr, Term), [], Output) :-
   translate_clause(Term, Clause),
   assertz(Clause, Ref),
   assertz(translated_from(Ref, Term)),
   clause(Head, Body, Ref),
+  % Just output the clause statically
   ( Body == true -> Show = Head; Show = (Head :- Body) ),
   with_output_to(string(Output), portray_clause(Show)),
   ( silent(false) ->
@@ -92,11 +124,11 @@ process_form(Execute, Space, parsed(function, FormStr, Term), [], Output) :-
       write(current_output, Output),
       format("\e[33m^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
   ; true),
-  ( Execute ->
-      add_sexp(Space, Term)
-  ; true).
+  add_sexp(Space, Term).
 
-process_form(_, In, _, _) :- format(atom(Msg), "failed to process form: ~w", [In]), throw(error(syntax_error(Msg), none)).
+process_form(_, In, _, _) :- 
+  format(atom(Msg), "failed to process form: ~w", [In]), 
+  throw(error(syntax_error(Msg), none)).
 
 write_to_output(Goals, Output) :-
   findall(
@@ -111,7 +143,43 @@ debug_print_goals(Goals, FormStr) :-
     forall(member(G, Goals), portray_clause((:- G))),
     format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
   ; true).
-  
+
+% Build the main/0 predicate from all goals
+build_main_predicate(GoalsList, MainClause) :-
+  % Flatten the list of goal lists into a single list
+  append(GoalsList, AllGoals),
+  % Add goal to print all collected results at the end
+  % We'll collect results using a global variable pattern
+  PrintGoal = (nb_getval(all_results, AllResults), forall(member(R, AllResults), writeln(R))),
+  InitGoal = nb_setval(all_results, []),
+  % Combine: initialize, run all goals, print results
+  append([[InitGoal], AllGoals, [PrintGoal]], FinalGoals),
+  % Create the main clause body
+  list_to_conjunction(FinalGoals, MainBody),
+  % Format as a clause
+  MainPredicate = (main :- MainBody),
+  with_output_to(string(MainClause), portray_clause(MainPredicate)).
+
+% Helper to convert list of goals to conjunction
+list_to_conjunction([], true).
+list_to_conjunction([G], G) :- !.
+list_to_conjunction([G|Gs], (G, Rest)) :- list_to_conjunction(Gs, Rest).
+
+% Collect specialized function goals for compilation output
+% This finds all specialized functions that were generated and returns goals to assert them
+collect_specialization_goals(Goals) :-
+  ho_specialization(_, SpecName),
+  % Find a clause for this specialized function
+  current_predicate(SpecName/Arity),
+  functor(Head, SpecName, Arity),
+  clause(Head, Body, Ref),
+  % Verify this clause was created by the specializer and get its source term
+  translated_from(Ref, SourceTerm),
+  % Return goals that register the function, assert clause and mapping
+  ( Body == true -> Show = Head ; Show = (Head :- Body) ),
+  Goals = [register_fun(SpecName), assertz(Show, R), assertz(translated_from(R, SourceTerm))].
+
+
 
 %Like blanks but counts newlines:
 newlines(C0, C2) --> blanks_to_nl, !, {C1 is C0+1}, newlines(C1,C2).

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -18,7 +18,16 @@ compile_metta_string(S, Output) :- compile_metta_string(S, Output, '&self').
 compile_metta_string(S, Output, Space) :-
   extract_forms(S, Forms),
   maplist(parse_form, Forms, ParsedForms),
-  maplist(process_form(false, Space), ParsedForms, _, OutputsList), !,
+  maplist(process_form(false, Space), ParsedForms, _, CompiledForms), !,
+  Prologue = [
+    ':- ensure_loaded(\'src/metta\').\n',
+    ':- use_module(library(memfile)).\n',
+    ':- new_memory_file(MF), open_memory_file(MF, write, ResultsStream), assertz(resultsMemFile(MF)), assertz(resultsStream(ResultsStream)).\n',
+    'write_result(Result) :- resultsStream(ResultsStream), format(ResultsStream, "~w~n", [Result]).\n'],
+  Epilogue = [
+    ':- resultsStream(S), close(S), resultsMemFile(MF), memory_file_to_string(MF, ResultsOutput), write(ResultsOutput), free_memory_file(MF).\n'
+  ],
+  append([Prologue, CompiledForms, Epilogue], OutputsList),
   atomic_list_concat(OutputsList, Output).
 
 %Extract function definitions, call invocations, and S-expressions part of &self space:
@@ -41,8 +50,10 @@ parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
                                                                             ; T=expression ).
 parse_form(runnable(S), parsed(runnable, S, Term)) :- sread(S, Term).
 
-% Second pass to compile / run / add the Terms. If Execute = true, we run the goals and
-% return them in Results (otherwise, we just return the compilation result in  Output):
+% Second pass to compile / run / add the Terms.
+% Output will always contain the compilation output as a result.
+% If Execute = true, the goals are run and return in Results.
+% If Execute = false, no goals are run and Results = [].
 process_form(Execute, Space, parsed(expression, _, Term), [], Output) :-
   ( silent(false) ->
       swrite(Term, STerm),
@@ -55,20 +66,24 @@ process_form(Execute, Space, parsed(expression, _, Term), [], Output) :-
   with_output_to(string(Output), portray_clause(:- 'add-atom'(Space, Term, true))).
 
 process_form(Execute, _, parsed(runnable, FormStr, Term), Result, Output) :-
-  translate_expr([collapse, Term], Goals, Result),
-  ( silent(false) ->
-      format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
-      forall(member(G, Goals), portray_clause((:- G))),
-      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
-  ; true),
+  translate_expr([collapse, Term], true, true, Goals, Result), 
+  % Conditional goal execution
   ( Execute ->
       call_goals(Goals)
-  ; Result = []),
+  ; true),
+  % We generate all goals and print them to Output.
   findall(
     GoalOutput,
     (member(G, Goals), with_output_to(string(GoalOutput), portray_clause((:- G)))),
     GoalOutputs),
-  atomic_list_concat(GoalOutputs, Output).
+  
+  atomic_list_concat(GoalOutputs, Output),
+  % We must print to the console at the end, in case the goals were actually called.
+  ( silent(false) ->
+      format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
+      forall(member(G, Goals), portray_clause((:- G))),
+      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
+  ; true).
 
 process_form(Execute, Space, parsed(function, FormStr, Term), [], Output) :-
   translate_clause(Term, Clause),

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -1,23 +1,39 @@
 :- use_module(library(readutil)). % read_file_to_string/3
 :- use_module(library(pcre)). % re_replace/4
 
-% Read Filename into string S and process it (S holds MeTTa code):
-% Execution results are stored in Results, while compiled Prolog output is
-% placed in Output.
-load_metta_file(Filename, Results, Output) :- load_metta_file(Filename, Results, Output, '&self').
-load_metta_file(Filename, Results, Output, Space) :- read_file_to_string(Filename, S, []),
-                                                     process_metta_string(S, Results, Output, Space).
+% Read Filename into string S and compile it to Prolog (S holds MeTTa code)
+compile_metta_file(Filename, Output) :- compile_metta_file(Filename, Output, '&self').
+compile_metta_file(Filename, Output, Space) :-
+  read_file_to_string(Filename, S, []),
+  compile_metta_string(S, Output, Space).
+
+% Read Filename into string S and process it:
+load_metta_file(Filename, Results) :- load_metta_file(Filename, Results, '&self').
+load_metta_file(Filename, Results, Space) :-
+  read_file_to_string(Filename, S, []),
+  process_metta_string(S, Results, Space).
+
+% Compile function definitions, invocations and S-expression part of &self space
+compile_metta_string(S, Output) :- compile_metta_string(S, Output, '&self').
+compile_metta_string(S, Output, Space) :-
+  extract_forms(S, Forms),
+  maplist(parse_form, Forms, ParsedForms),
+  maplist(process_form(false, Space), ParsedForms, _, OutputsList), !,
+  atomic_list_concat(OutputsList, Output).
 
 %Extract function definitions, call invocations, and S-expressions part of &self space:
-process_metta_string(S, Results, Output) :- process_metta_string(S, Results, Output, '&self').
-process_metta_string(S, Results, Output, Space) :-
+process_metta_string(S, Results) :- process_metta_string(S, Results, '&self').
+process_metta_string(S, Results, Space) :-
+  extract_forms(S, Forms),
+  maplist(parse_form, Forms, ParsedForms),
+  maplist(process_form(true, Space), ParsedForms, ResultsList, _), !,
+  append(ResultsList, Results).
+
+% Extract top forms from MeTTa string
+extract_forms(S, Forms) :-
   string_codes(S, Cs),
   strip(Cs, 0, Codes),
-  phrase(top_forms(Forms, 1), Codes),
-  maplist(parse_form, Forms, ParsedForms),
-  maplist(process_form(Space), ParsedForms, ResultsList, OutputsList), !,
-  append(ResultsList, Results),
-  atomic_list_concat(OutputsList, Output).
+  phrase(top_forms(Forms, 1), Codes).
 
 %First pass to convert MeTTa to Prolog Terms and register functions:
 parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
@@ -25,26 +41,27 @@ parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
                                                                             ; T=expression ).
 parse_form(runnable(S), parsed(runnable, S, Term)) :- sread(S, Term).
 
-%Second pass to compile / run / add the Terms:
-process_form(Space, parsed(expression, _, Term), [], Output) :-
+% Second pass to compile / run / add the Terms. If Execute = true, we run the goals and
+% return them in Results (otherwise, we just return the compilation result in  Output):
+process_form(Execute, Space, parsed(expression, _, Term), [], Output) :-
   ( silent(false) ->
       swrite(Term, STerm),
       format("\e[33m--> metta sexpr -->~n\e[36m~w~n", [STerm]),
       format("\e[33m^^^^^^^^^^^^^^^^^^^~n\e[0m")
     ; true),
-  ( execute(true) ->
+  ( Execute ->
     'add-atom'(Space, Term, true)
     ; true),
   with_output_to(string(Output), portray_clause('add-atom'(Space, Term, true))).
 
-process_form(_, parsed(runnable, FormStr, Term), Result, Output) :-
+process_form(Execute, _, parsed(runnable, FormStr, Term), Result, Output) :-
   translate_expr([collapse, Term], Goals, Result),
   ( silent(false) ->
       format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
       forall(member(G, Goals), portray_clause((:- G))),
       format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
   ; true),
-  ( execute(true) ->
+  ( Execute ->
       call_goals(Goals)
   ; Result = []),
   findall(
@@ -53,7 +70,7 @@ process_form(_, parsed(runnable, FormStr, Term), Result, Output) :-
     GoalOutputs),
   atomic_list_concat(GoalOutputs, Output).
 
-process_form(Space, parsed(function, FormStr, Term), [], Output) :-
+process_form(Execute, Space, parsed(function, FormStr, Term), [], Output) :-
   translate_clause(Term, Clause),
   assertz(Clause, Ref),
   assertz(translated_from(Ref, Term)),
@@ -65,7 +82,7 @@ process_form(Space, parsed(function, FormStr, Term), [], Output) :-
       write(current_output, Output),
       format("\e[33m^^^^^^^^^^^^^^^^^^^^^^~n\e[0m")
   ; true),
-  ( execute(true) ->
+  ( Execute ->
       add_sexp(Space, Term)
   ; true
   ).

--- a/src/main.pl
+++ b/src/main.pl
@@ -1,4 +1,22 @@
 :- ensure_loaded(metta).
+:- use_module(library(optparse)).
+:- use_module(library(option)).
+
+options_spec(
+    [ [opt(mode), meta(mode), type(atom), default('COMPILER'),
+        shortflags([m]),   longflags(['mode']),
+        help(['The operation mode of the PeTTa compiler:'
+             ,'   COMPILER: Output only the compiled Prolog clauses, ignoring any runnables.'
+             ,'   INTERPRETER: Interpret the provided MeTTa program and print the result of all runnables.'
+             ,'   TEST_INTEROP:  Run the Prolog interop example'
+             ,'   TEST_MORK: Run the Mork test'])]
+      , [opt(silent_opt), type(atom), default(true),
+        shortflags([s]), longflags(['silent']),
+        help(['Whether to print each MeTTa form as it is parsed, followed by its Prolog translation.'])]
+      , [opt(output_file), meta(file), type(atom), default('NADA'),
+        shortflags([o]), longflags(['output']),
+        help(['Where to store the compiled MeTTa code'])]
+    ]).
 
 prologfunc(X,Y) :- Y is X+1.
 
@@ -8,16 +26,42 @@ prolog_interop_example :- register_fun(prologfunc),
                           mettafunc(30, R),
                           format("mettafunc(30) = ~w~n", [R]).
 
+% Globals:
+% * silent(true|false): Whether to print each MeTTa form as it is parsed, followed by its Prolog translation.
+% * execute(true|false): Whether to execute any runnables parsed in the MeTTa program.
 main :- current_prolog_flag(argv, Args),
-        ( Args = [] -> prolog_interop_example
-        ; Args = [mork] -> prolog_interop_example,
-                           mork_test
-        ; Args = [File|_] -> file_directory_name(File, Dir),
-                             assertz(working_dir(Dir)),
-                             load_metta_file(File,Results),
-                             maplist(swrite,Results,ResultsR),
-                             maplist(format("~w~n"), ResultsR)
-        ),
+        options_spec(Spec),
+        opt_parse(Spec, Args, Opts, PositionalArgs),
+        option(mode(Mode), Opts),
+        option(silent_opt(Silent), Opts),
+        assertz(silent(Silent)),
+        % format("Options: ~w~n", Opts),
+        % format("PositionalArgs: ~w~n", PositionalArgs),
+        (Mode = 'TEST_INTEROP' ->
+                prolog_interop_example
+        ; (Mode = 'TEST_MORK') ->
+                prolog_interop_example,
+                mork_test
+        ; ([] = PositionalArgs) ->
+                format("Expected at least 1 positional argument with the MeTTa program to read.~n")
+        ; (Mode = 'INTERPRETER', [File|_] = PositionalArgs) ->
+                file_directory_name(File, Dir),
+                assertz(working_dir(Dir)),
+                assertz(execute(true)),
+                load_metta_file(File,Results, _),
+                maplist(swrite,Results,ResultsR),
+                maplist(format("~w~n"), ResultsR)
+        ; (Mode = 'COMPILER', [File|_] = PositionalArgs) ->
+                option(output_file(OutputFile), Opts),
+                file_directory_name(File, Dir),
+                assertz(working_dir(Dir)),
+                assertz(execute(false)),
+                load_metta_file(File,_, Output),
+                ( OutputFile = 'NADA' ->
+                    write(current_output, Output)
+                ; open(OutputFile, write, OutputFd),
+                  write(OutputFd, Output)
+                )),
         halt.
 
 :- initialization(main, main).

--- a/src/main.pl
+++ b/src/main.pl
@@ -28,7 +28,6 @@ prolog_interop_example :- register_fun(prologfunc),
 
 % Globals:
 % * silent(true|false): Whether to print each MeTTa form as it is parsed, followed by its Prolog translation.
-% * execute(true|false): Whether to execute any runnables parsed in the MeTTa program.
 main :- current_prolog_flag(argv, Args),
         options_spec(Spec),
         opt_parse(Spec, Args, Opts, PositionalArgs),
@@ -47,16 +46,14 @@ main :- current_prolog_flag(argv, Args),
         ; (Mode = 'INTERPRETER', [File|_] = PositionalArgs) ->
                 file_directory_name(File, Dir),
                 assertz(working_dir(Dir)),
-                assertz(execute(true)),
-                load_metta_file(File,Results, _),
+                load_metta_file(File,Results),
                 maplist(swrite,Results,ResultsR),
                 maplist(format("~w~n"), ResultsR)
         ; (Mode = 'COMPILER', [File|_] = PositionalArgs) ->
                 option(output_file(OutputFile), Opts),
                 file_directory_name(File, Dir),
                 assertz(working_dir(Dir)),
-                assertz(execute(false)),
-                load_metta_file(File,_, Output),
+                compile_metta_file(File,Output),
                 ( OutputFile = 'NADA' ->
                     write(current_output, Output)
                 ; open(OutputFile, write, OutputFd),

--- a/src/main.pl
+++ b/src/main.pl
@@ -46,6 +46,7 @@ main :- current_prolog_flag(argv, Args),
         ; (Mode = 'INTERPRETER', [File|_] = PositionalArgs) ->
                 file_directory_name(File, Dir),
                 assertz(working_dir(Dir)),
+                (getenv("PETTA_HOME", PETTA_HOME) -> assertz(petta_home(PETTA_HOME)) ; assertz(petta_home(""))),
                 load_metta_file(File,Results),
                 maplist(swrite,Results,ResultsR),
                 maplist(format("~w~n"), ResultsR)

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -243,22 +243,39 @@ retractPredicate(G, true) :- retract(G), !.
 retractPredicate(_, false).
 
 %%% Library / Import: %%%
-ensure_metta_ext(Path, Path) :- file_name_extension(_, metta, Path), !.
-ensure_metta_ext(Path, PathWithExt) :- file_name_extension(Path, metta, PathWithExt).
 
-'import!'(Space, File, true) :- catch(importer_helper(Space, File), _, fail).
-importer_helper(Space, File) :- atom_string(File, SFile),
-                                working_dir(Base),
-                                ( file_name_extension(ModPath, 'py', SFile)
-                                  -> absolute_file_name(SFile, Path, [relative_to(Base)]),
-                                     file_directory_name(Path, Dir),
-                                     file_base_name(ModPath, ModuleName),
-                                     py_call(sys:path:append(Dir), _),
-                                     py_call(builtins:'__import__'(ModuleName), _)
-                                   ; ( Path = SFile ; atomic_list_concat([Base, '/', SFile], Path) ),
-                                     ensure_metta_ext(Path, PathWithExt),
-                                     exists_file(PathWithExt), !,
-                                     load_metta_file(PathWithExt, _, Space) ).
+% Checks for file existence and returns full path and extension
+ensure_file_exists(PathWithExt, PathWithExt, Ext) :-
+  exists_file(PathWithExt), !,
+  file_name_extension(_, Ext, PathWithExt).
+ensure_file_exists(Path, PathWithExt, Ext) :-
+  file_name_extension(Path, 'metta', PathWithExt),
+  exists_file(PathWithExt), !,
+  Ext = 'metta'.
+ensure_file_exists(Path, PathWithExt, Ext) :-
+  file_name_extension(Path, 'py', PathWithExt),
+  exists_file(PathWithExt),
+  Ext = 'py'.
+
+'import!'(Space, File, true) :- catch(import_file(Space, File), _, (writeln(fail), fail)).
+% If <> are used, then interpret import path as relative to PeTTa installation directory.
+% Otherwise, try the different search directories.
+import_file(Space, File) :- split_string(File, "<>", "", L),
+                            (L = ["", RelPath, ""] -> petta_home(Base) ; any_base(Base), RelPath = File),
+                            absolute_file_name(RelPath, AbsPath, [relative_to(Base)]),
+                            ensure_file_exists(AbsPath, AbsPathWithExt, Ext), !,
+                            (Ext = 'metta' ->
+                                load_metta_file(AbsPathWithExt, _, Space)
+                            ; Ext = 'py' ->
+                                file_directory_name(AbsPathWithExt, Dir),
+                                file_base_name(AbsPathWithExt, ModName),
+                                py_call(sys:path:append(Dir), _),
+                                py_call(builtins:'__import__'(ModName), _)
+                            ).
+
+% Import paths may be relative to the PeTTa installation dir, the working directory
+% or just absolute.
+any_base(Base) :- (Base = "" ; working_dir(Base) ; petta_home(Base)).
 
 :- dynamic translator_rule/1.
 'add-translator-rule!'(HV, true) :- ( translator_rule(HV)

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -8,7 +8,7 @@ constrain_args([F, A, B], Out, Goals) :- nonvar(F),
                                          append(G1, G2, Goals), !.
 constrain_args([F|Args], Var, Goals) :- atom(F),
                                         fun(F), !,
-                                        translate_expr([F|Args], GoalsExpr, Var),
+                                        translate_expr([F|Args], false, false, GoalsExpr, Var),
                                         flatten(GoalsExpr, Goals).
 constrain_args(In, Out, Goals) :- maplist(constrain_args, In, Out, NestedGoalsList),
                                   flatten(NestedGoalsList, Goals), !.
@@ -22,7 +22,7 @@ translate_clause(Input, (Head :- BodyConj), ConstrainArgs) :-
                                                                 ; Args1 = Args0, GoalsPrefix = [] ),
                                                catch(nb_getval(F, Prev), _, Prev = []),
                                                nb_setval(F, [fun_meta(Args1, BodyExpr) | Prev]),
-                                               translate_expr(BodyExpr, GoalsBody, ExpOut),
+                                               translate_expr(BodyExpr, false, false, GoalsBody, ExpOut),
                                                (  nonvar(ExpOut) , ExpOut = partial(Base,Bound)
                                                -> current_predicate(Base/Arity), length(Bound, N), M is (Arity - N) - 1,
                                                   length(ExtraArgs, M), append([Bound,ExtraArgs,[Out]],CallArgs), Goal =.. [Base|CallArgs],
@@ -67,7 +67,7 @@ reduce([F|Args], Out) :- nonvar(F), atom(F), fun(F)
 agg_reduce(AF, Acc, Val, NewAcc) :- reduce([AF, Acc, Val], NewAcc).
 
 %Combined expr translation to goals list
-translate_expr_to_conj(Input, Conj, Out) :- translate_expr(Input, Goals, Out),
+translate_expr_to_conj(Input, Conj, Out) :- translate_expr(Input, false, false, Goals, Out),
                                             goals_list_to_conj(Goals, Conj).
 
 %Special stream operation rewrite rules before main translation
@@ -90,32 +90,39 @@ rewrite_streamops(X, X).
 safe_rewrite_streamops(In, Out) :- ( compound(In), In = [Op|_], atom(Op) -> rewrite_streamops(In, Out)
                                                                           ; Out = In).
 
+% Wrapper for interpreter mode: translate_expr/3 defaults to TopLevel=false, PrintResults=false
+translate_expr(X, Goals, Out) :- translate_expr(X, false, false, Goals, Out).
 %Turn MeTTa code S-expression into goals list:
-translate_expr(X, [], X)          :- ((var(X) ; atomic(X)) ; X = partial(_,_)), !.
-translate_expr([H0|T0], Goals, Out) :-
+translate_expr(X, _TopLevel, _PrintResults, [], X)          :- ((var(X) ; atomic(X)) ; X = partial(_,_)), !.
+translate_expr([H0|T0], TopLevel, PrintResults, Goals, Out) :-
         safe_rewrite_streamops([H0|T0],[H|T]),
-        translate_expr(H, GsH, HV),
+        translate_expr(H, false, PrintResults, GsH, HV),
         %--- Translator rules ---:
         ( nonvar(HV), translator_rule(HV) -> ( catch(match('&self', [':', HV, TypeChain], TypeChain, TypeChain), _, fail)
                                                -> TypeChain = [->|Xs],
                                                   append(ArgTypes, [_], Xs),
                                                   translate_args_by_type(T, ArgTypes, GsT, T1)
                                                 ; translate_args(T, GsT, T1) ),
-                                             append(T1,[Gs],Args),
-                                             HookCall =.. [HV|Args],
-                                             call(HookCall),
-                                             translate_expr(Gs, GsE, Out),
-                                             append([GsH,GsT,GsE],Goals)
+                                              append(T1,[Gs],Args),
+                                              HookCall =.. [HV|Args],
+                                              call(HookCall),
+                                              translate_expr(Gs, false, PrintResults, GsE, Out),
+                                              append([GsH,GsT,GsE],Goals)
         %--- Non-determinism ---:
         ; HV == superpose, T = [Args], is_list(Args) -> build_superpose_branches(Args, Out, Branches),
                                                         disj_list(Branches, Disj),
                                                         append(GsH, [Disj], Goals)
         ; HV == collapse, T = [E] -> translate_expr_to_conj(E, Conj, EV),
-                                     append(GsH, [findall(EV, Conj, Out)], Goals)
+                                     % We only print if PrintResults = true and this is a top-level form
+                                     ( (TopLevel, PrintResults) -> 
+                                         append(GsH, [(findall(EV, (Conj, write_result(EV)), Out))], Goals)
+                                     ; 
+                                         append(GsH, [(findall(EV, Conj, Out))], Goals)
+                                     )
         ; HV == cut, T = [] -> append(GsH, [(!)], Goals),
                                Out = true
         ; HV == test, T = [Expr, Expected] -> translate_expr_to_conj(Expr, Conj, Val),
-                                              translate_expr(Expected, GsE, ExpVal),
+                                              translate_expr(Expected, false, PrintResults, GsE, ExpVal),
                                               Goal1 = ( findall(Val, Conj, Results),
                                                         (Results = [Actual] -> true
                                                                              ; Actual = Results ) ),
@@ -131,13 +138,13 @@ translate_expr([H0|T0], Goals, Out) :-
         ; HV == transaction, T = [X] -> translate_expr_to_conj(X, Conj, Out),
                                         append(GsH, [transaction(Conj)], Goals)
         %--- Sequential execution ---:
-        ; HV == progn, T = Exprs -> translate_args(Exprs, GsList, Outs),
+        ; HV == progn, T = Exprs -> translate_args(Exprs, false, PrintResults, GsList, Outs),
                                     append(GsH, GsList, Tmp),
                                     last(Outs, Out),
                                     Goals = Tmp
         ; HV == prog1, T = Exprs -> Exprs = [First|Rest],
-                                    translate_expr(First, GsF, Out),
-                                    translate_args(Rest, GsRest, _),
+                                    translate_expr(First, false, PrintResults, GsF, Out),
+                                    translate_args(Rest, false, PrintResults, GsRest, _),
                                     append(GsH, GsF, Tmp1),
                                     append(Tmp1, GsRest, Goals)
         %--- Conditionals ---:
@@ -168,24 +175,24 @@ translate_expr([H0|T0], Goals, Out) :-
                                                        translate_case(PairsExpr, Kv, Out, IfGoal, KeyGoal),
                                                        append([GsH, Gk, KeyGoal, [IfGoal]], Goals) )
         %--- Unification constructs ---:
-        ; (HV == let ; HV == chain), T = [Pat, Val, In] -> translate_expr(Pat, Gp, Pv),
-                                                           translate_expr(Val, Gv, V),
-                                                           translate_expr(In,  Gi, Out),
+        ; (HV == let ; HV == chain), T = [Pat, Val, In] -> translate_expr(Pat, false, PrintResults, Gp, Pv),
+                                                           translate_expr(Val, false, PrintResults, Gv, V),
+                                                           translate_expr(In,  false, PrintResults, Gi, Out),
                                                            append([GsH,[(Pv=V)],Gp,Gv,Gi], Goals)
         ; HV == 'let*', T = [Binds, Body] -> letstar_to_rec_let(Binds,Body,RecLet),
-                                             translate_expr(RecLet,  Goals, Out)
+                                             translate_expr(RecLet, false, PrintResults, Goals, Out)
         ; HV == sealed, T = [Vars, Expr] -> translate_expr_to_conj(Expr, Con, Val),
                                             Goals = [copy_term(Vars,[Con,Val],_,[Ncon,Out]),Ncon]
         %--- Iterating over non-deterministic generators without reification ---:
         ; HV == 'forall', T = [GF, TF]
           -> ( is_list(GF) -> GF = [GFH|GFA],
-                              translate_expr(GFH, GsGFH, GFHV),
-                              translate_args(GFA, GsGFA, GFAv),
+                              translate_expr(GFH, false, PrintResults, GsGFH, GFHV),
+                              translate_args(GFA, false, PrintResults, GsGFA, GFAv),
                               append(GsGFH, GsGFA, GsGF),
                               GenList = [GFHV|GFAv]
-                            ; translate_expr(GF, GsGF, GFHV),
+                            ; translate_expr(GF, false, PrintResults, GsGF, GFHV),
                               GenList = [GFHV] ),
-             translate_expr(TF, GsTF, TFHV),
+             translate_expr(TF, false, PrintResults, GsTF, TFHV),
              TestList = [TFHV, V],
              goals_list_to_conj(GsGF, GPre),
              GenGoal = (GPre, reduce(GenList, V)),
@@ -193,16 +200,16 @@ translate_expr([H0|T0], Goals, Out) :-
              append(Tmp0, [( forall(GenGoal, ( reduce(TestList, Truth), Truth == true )) -> Out = true ; Out = false )], Goals)
         ; HV == 'foldall', T = [AF, GF, InitS]
           -> translate_expr_to_conj(InitS, ConjInit, Init),
-             translate_expr(AF, GsAF, AFV),
+             translate_expr(AF, false, PrintResults, GsAF, AFV),
              ( GF = [M|_], (M==match ; M==let ; M=='let*') -> LambdaGF = ['|->', [], GF],
-                                                              translate_expr(LambdaGF, GsGF, GFHV),
+                                                              translate_expr(LambdaGF, false, PrintResults, GsGF, GFHV),
                                                               GenList = [GFHV]
              ; is_list(GF) -> GF = [GFH|GFA],
-                              translate_expr(GFH, GsGFH, GFHV),
-                              translate_args(GFA, GsGFA, GFAv),
+                              translate_expr(GFH, false, PrintResults, GsGFH, GFHV),
+                              translate_args(GFA, false, PrintResults, GsGFA, GFAv),
                               append(GsGFH, GsGFA, GsGF),
                               GenList = [GFHV|GFAv]
-                            ; translate_expr(GF, GsGF, GFHV),
+                            ; translate_expr(GF, false, PrintResults, GsGF, GFHV),
                               GenList = [GFHV] ),
              append(GsH, GsAF, Tmp1),
              append(Tmp1, GsGF, Tmp2),
@@ -249,29 +256,29 @@ translate_expr([H0|T0], Goals, Out) :-
         ; ( HV == 'add-atom' ; HV == 'remove-atom' ), T = [_,_] -> append(T, [Out], RawArgs),
                                                                    Goal =.. [HV|RawArgs],
                                                                    append(GsH, [Goal], Goals)
-        ; HV == match, T = [Space, Pattern, Body] -> translate_expr(Space, G1, S),
-                                                     translate_expr(Body, GsB, Out),
+        ; HV == match, T = [Space, Pattern, Body] -> translate_expr(Space, false, PrintResults, G1, S),
+                                                     translate_expr(Body, false, PrintResults, GsB, Out),
                                                      append(G1, [match(S, Pattern, Out, Out)], G2),
                                                      append(G2, GsB, Goals)
         %--- Predicate to compiled goal ---:
         ; HV == translatePredicate, T = [Expr] -> Expr = [S|Args],
-                                                  translate_args(Args, GsArgs, ArgsOut),
+                                                  translate_args(Args, false, PrintResults, GsArgs, ArgsOut),
                                                   Goal =.. [S|ArgsOut],
                                                   append(GsH, GsArgs, Inner),
                                                   append(Inner, [Goal], Goals)
         %--- Manual dispatch options: ---
         %Generate a predicate call on compilation, translating Args for nesting:
         ; HV == call,  T = [Expr] -> Expr = [F|Args],
-                                     translate_args(Args, GsArgs, ArgsOut),
+                                     translate_args(Args, false, PrintResults, GsArgs, ArgsOut),
                                      append(GsH, GsArgs, Inner),
                                      append(ArgsOut, [Out], CallArgs),
                                      Goal =.. [F|CallArgs],
                                      append(Inner, [Goal], Goals)
         %Produce a dynamic dispatch, translating Args for nesting:
-        ; HV == reduce, T = [Expr] -> ( var(Expr) -> translate_expr(Expr, GsH, ExprOut),
+        ; HV == reduce, T = [Expr] -> ( var(Expr) -> translate_expr(Expr, false, PrintResults, GsH, ExprOut),
                                                      Goals = [reduce(ExprOut, Out)|GsH]
                                                    ; Expr = [F|Args],
-                                                     translate_args(Args, GsArgs, ArgsOut),
+                                                     translate_args(Args, false, PrintResults, GsArgs, ArgsOut),
                                                      append(GsH, GsArgs, Inner),
                                                      ExprOut = [F|ArgsOut],
                                                      append(Inner, [reduce(ExprOut, Out)], Goals) )
@@ -284,7 +291,7 @@ translate_expr([H0|T0], Goals, Out) :-
                                      Out = Expr,
                                      Goals = Inner
         ; HV == 'catch', T = [Expr] ->
-          translate_expr(Expr, GsExpr, ExprOut),
+          translate_expr(Expr, false, PrintResults, GsExpr, ExprOut),
           append(GsH, [], Inner),
           goals_list_to_conj(GsExpr, Conj),
           Goal = catch((Conj, Out = ExprOut),
@@ -293,7 +300,7 @@ translate_expr([H0|T0], Goals, Out) :-
                                                       ; Out = ['Error', Exception])),
           append(Inner, [Goal], Goals)
         %--- Automatic 'smart' dispatch, translator deciding when to create a predicate call, data list, or dynamic dispatch: ---
-        ; translate_args(T, GsT, AVs),
+        ; translate_args(T, false, PrintResults, GsT, AVs),
           append(GsH, GsT, Inner),
           %Known function => direct call:
           ( is_list(AVs), 
@@ -347,7 +354,7 @@ typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchG
 translate_args_by_type([], _, [], []) :- !.
 translate_args_by_type([A|As], [T|Ts], GsOut, [AV|AVs]) :-
                       ( T == 'Expression' -> AV = A, GsA = []
-                                           ; translate_expr(A, GsA1, AV),
+                                           ; translate_expr(A, false, false, GsA1, AV),
                                              ( (T == '%Undefined%' ; T == 'Atom')
                                                -> GsA = GsA1
                                                 ; append(GsA1, [('get-type'(AV, T) *-> true ; 'get-metatype'(AV, T))], GsA))),
@@ -356,7 +363,7 @@ translate_args_by_type([A|As], [T|Ts], GsOut, [AV|AVs]) :-
 
 %Handle data list:
 eval_data_term(X, [], X) :- (var(X); atomic(X)), !.
-eval_data_term([F|As], Goals, Val) :- ( atom(F), fun(F) -> translate_expr([F|As], Goals, Val)
+eval_data_term([F|As], Goals, Val) :- ( atom(F), fun(F) -> translate_expr([F|As], false, false, Goals, Val)
                                                          ; eval_data_list([F|As], Goals, Val) ).
 
 %Handle data list entry:
@@ -390,11 +397,14 @@ translate_case([[K,VExpr]|Rs], Kv, Out, Goal, KGo) :- translate_expr_to_conj(VEx
                                                                     Goal = ((Kv = Kc) -> Then ; Next) ),
                                                       append([Gc,KGi], KGo).
 
+% Wrapper for interpreter mode
+translate_args(Xs, Goals, Vs) :- translate_args(Xs, false, false, Goals, Vs).
 %Translate arguments recursively:
-translate_args([], [], []).
-translate_args([X|Xs], Goals, [V|Vs]) :- translate_expr(X, G1, V),
-                                         translate_args(Xs, G2, Vs),
-                                         append(G1, G2, Goals).
+translate_args([], _TopLevel, _PrintResults, [], []).
+translate_args([X|Xs], TopLevel, PrintResults, Goals, [V|Vs]) :- 
+    translate_expr(X, TopLevel, PrintResults, G1, V),
+    translate_args(Xs, TopLevel, PrintResults, G2, Vs),
+    append(G1, G2, Goals).
 
 %Build A ; B ; C ... from a list:
 disj_list([G], G).

--- a/src/translator_backup.pl
+++ b/src/translator_backup.pl
@@ -324,101 +324,32 @@ translate_expr([H0|T0], Execute, Goals, Out) :-
         %--- Automatic 'smart' dispatch, translator deciding when to create a predicate call, data list, or dynamic dispatch: ---
         ; translate_args(T, Execute, GsT, AVs),
           append(GsH, GsT, Inner),
-          % Old implementation
-          % smart_dispatch(HV, T, Execute, GsH, GsT, Inner, AVs, Goals, Out)).
-          ( Execute ->
-              smart_dispatch_execute(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-            ; smart_dispatch_compile(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-          )
-        ).
-
-%Automatic 'smart' dispatch implementation:
-smart_dispatch(HV, T, Execute, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; (Execute ->
-          build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
-        ; append(Inner, [runtime_call(Fun, AVs, Out)], Goals)
-        )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> ( Execute -> Out = [HV|AVs], Goals = Inner
-                                        ; append(Inner, [runtime_call(HV, AVs, Out)], Goals) )
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=true (interpreter mode):
-smart_dispatch_execute(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; length(AllAVs, N),
-        Arity is N + 1,
-        ( maybe_specialize_call(Fun, AllAVs, Out, Goal)
-          -> % Specialization succeeded during execution - use it
-             append(Inner, [Goal], Goals)
-        ; ( current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail) ),
-          \+ ( current_op(_, _, Fun), Arity =< 2 )
-          -> % Direct call during execution
-             append(AllAVs, [Out], Args),
-             Goal =.. [Fun|Args],
-             append(Inner, [Goal], Goals)
-        ; Out = partial(Fun, AllAVs),
-          append(Inner, [], Goals)
-        )
-      )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> Out = [HV|AVs], Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(true, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=false (compiler mode):
-smart_dispatch_compile(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Check for function call that might need type-aware handling:
-  ( atom(HV)
-    -> % Use runtime_call_typed to defer type checking to runtime
-       % Pass original unevaluated arguments T, not translated AVs
-       append(GsH, [runtime_call_typed(HV, T, Out)], Goals)
-  ; compound(HV), HV = partial(Fun, Bound)
-    -> % Partial application - append bound args to new args at runtime
-       append(GsH, [runtime_call_typed_partial(Fun, Bound, T, Out)], Goals)
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(false, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
+          %Known function => direct call:
+          ( is_list(AVs), 
+            ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
+            ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
+            ) % Check for type definition [:,HV,TypeChain]
+            -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
+               ( TypeChains \= []
+                 -> maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
+                            typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
+                    disj_list(Branches, Disj),
+                    Goals = [Disj]
+              ; (Execute ->
+                  build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
+                ; append(Inner, [runtime_call(Fun, AVs, Out)], Goals)
+                )
+          %Literals (numbers, strings, etc.), known non-function atom => data:
+          ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
+                                           Goals = Inner
+          ; atom(HV), \+ fun(HV) -> ( Execute -> Out = [HV|AVs], Goals = Inner
+                                                ; append(Inner, [runtime_call(HV, AVs, Out)], Goals) )
+          %Plain data list: evaluate inner fun-sublists
+          ; is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
+                           append(Inner, Gd, Goals),
+                           Out = [HV1|AVs]
+          %Unknown head (var/compound) => runtime dispatch:
+          ; append(Inner, [reduce([HV|AVs], Out)], Goals) )).
 
 %Generate actual function call or partial if arity not complete:
 build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :- 
@@ -457,46 +388,6 @@ runtime_call(Fun, AVs, Out) :-
     ; % Not callable as predicate - use reduce for proper handling
       reduce([Fun|AVs], Out)
     ).
-
-% Runtime type-aware call: checks for type information at runtime and handles argument translation
-% This is used by the compiler to defer type-aware translation to runtime
-runtime_call_typed(Fun, OrigArgs, Out) :-
-    % Check for type information at runtime
-    findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-    ( TypeChains \= [], TypeChains = [TypeChain|_]
-      -> % Type information exists - translate arguments according to their types
-         TypeChain = [->|Xs],
-         append(ArgTypes, [_OutType], Xs),
-         translate_args_by_type_runtime(OrigArgs, ArgTypes, AVs),
-         runtime_call(Fun, AVs, Out)
-    ; % No type information - evaluate all arguments and call
-      translate_args_runtime(OrigArgs, AVs),
-      runtime_call(Fun, AVs, Out)
-    ).
-
-% Helper: translate arguments at runtime according to their types
-translate_args_by_type_runtime([], _, []) :- !.
-translate_args_by_type_runtime([A|As], [T|Ts], [AV|AVs]) :-
-    ( T == 'Expression' 
-      -> % Keep as data - don't evaluate
-         AV = A
-    ; % Evaluate the argument
-      translate_expr_to_conj(A, true, Conj, AV),
-      call(Conj)
-    ),
-    translate_args_by_type_runtime(As, Ts, AVs).
-
-% Helper: translate/evaluate all arguments at runtime (no type info)
-translate_args_runtime([], []) :- !.
-translate_args_runtime([A|As], [AV|AVs]) :-
-    translate_expr_to_conj(A, true, Conj, AV),
-    call(Conj),
-    translate_args_runtime(As, AVs).
-
-% Runtime type-aware call for partial applications
-runtime_call_typed_partial(Fun, Bound, NewArgs, Out) :-
-    append(Bound, NewArgs, AllArgs),
-    runtime_call_typed(Fun, AllArgs, Out).
 
 %Type function call generation, returns function call plus typechecks for input and output:
 typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal) :-

--- a/src/translator_backup2.pl
+++ b/src/translator_backup2.pl
@@ -322,103 +322,44 @@ translate_expr([H0|T0], Execute, Goals, Out) :-
                                                       ; Out = ['Error', Exception])),
           append(Inner, [Goal], Goals)
         %--- Automatic 'smart' dispatch, translator deciding when to create a predicate call, data list, or dynamic dispatch: ---
-        ; translate_args(T, Execute, GsT, AVs),
-          append(GsH, GsT, Inner),
-          % Old implementation
-          % smart_dispatch(HV, T, Execute, GsH, GsT, Inner, AVs, Goals, Out)).
-          ( Execute ->
-              smart_dispatch_execute(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-            ; smart_dispatch_compile(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-          )
-        ).
-
-%Automatic 'smart' dispatch implementation:
-smart_dispatch(HV, T, Execute, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; (Execute ->
-          build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
-        ; append(Inner, [runtime_call(Fun, AVs, Out)], Goals)
-        )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> ( Execute -> Out = [HV|AVs], Goals = Inner
-                                        ; append(Inner, [runtime_call(HV, AVs, Out)], Goals) )
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=true (interpreter mode):
-smart_dispatch_execute(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; length(AllAVs, N),
-        Arity is N + 1,
-        ( maybe_specialize_call(Fun, AllAVs, Out, Goal)
-          -> % Specialization succeeded during execution - use it
-             append(Inner, [Goal], Goals)
-        ; ( current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail) ),
-          \+ ( current_op(_, _, Fun), Arity =< 2 )
-          -> % Direct call during execution
-             append(AllAVs, [Out], Args),
-             Goal =.. [Fun|Args],
-             append(Inner, [Goal], Goals)
-        ; Out = partial(Fun, AllAVs),
-          append(Inner, [], Goals)
-        )
-      )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> Out = [HV|AVs], Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(true, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=false (compiler mode):
-smart_dispatch_compile(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Check for function call that might need type-aware handling:
-  ( atom(HV)
-    -> % Use runtime_call_typed to defer type checking to runtime
-       % Pass original unevaluated arguments T, not translated AVs
-       append(GsH, [runtime_call_typed(HV, T, Out)], Goals)
-  ; compound(HV), HV = partial(Fun, Bound)
-    -> % Partial application - append bound args to new args at runtime
-       append(GsH, [runtime_call_typed_partial(Fun, Bound, T, Out)], Goals)
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(false, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
+        ; ( ( atom(HV), fun(HV), Fun = HV, IsPartial = false
+            ; compound(HV), HV = partial(Fun, Bound), IsPartial = true
+            )
+            % Check for type definition FIRST (before translating args!)
+            -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
+               ( TypeChains \= []
+                 -> % HAS TYPES - use typed translation (same as before)
+                    maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
+                            typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
+                    disj_list(Branches, Disj),
+                    Goals = [Disj]
+               ; % NO TYPES - translate args normally and dispatch
+                 translate_args(T, Execute, GsT, AVs),
+                 ( IsPartial -> append(Bound, AVs, AllAVs) ; AllAVs = AVs ),
+                 append(GsH, GsT, Inner),
+                 (Execute
+                   -> build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals)
+                   ; Goals = [runtime_call(Fun, T, Out)]  % Pass expressions, not values!
+                 )
+               )
+          ; % Not a known function - translate args for remaining branches
+            translate_args(T, Execute, GsT, AVs),
+            append(GsH, GsT, Inner),
+            ( % Literals (numbers, strings, etc.)
+              ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs], Goals = Inner
+            ; % Non-function atom
+              atom(HV), \+ fun(HV) -> ( Execute
+                                         -> Out = [HV|AVs], Goals = Inner
+                                         ; Goals = [runtime_call(HV, T, Out)]  % Pass expressions!
+                                       )
+            ; % Data list
+              is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
+                             append(Inner, Gd, Goals),
+                             Out = [HV1|AVs]
+            ; % Unknown head (var/compound) => runtime dispatch
+              append(Inner, [reduce([HV|AVs], Out)], Goals)
+            )
+          )).
 
 %Generate actual function call or partial if arity not complete:
 build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :- 
@@ -437,66 +378,82 @@ build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :-
       append(Inner, Extra, Goals)
     ).
 
-% Runtime call helper: replicates what build_call_or_partial does when Execute=true
-% This allows compiled programs to benefit from specialization
+% Runtime call helper: accepts unevaluated expressions and evaluates them according to type declarations
+% This allows compiled programs to respect Expression types and other type annotations
 % Falls back to reduce for edge cases (partial applications, non-callables, etc.)
-runtime_call(Fun, AVs, Out) :-
-    length(AVs, N),
-    Arity is N + 1,
-    ( maybe_specialize_call(Fun, AVs, Out, Goal)
-      -> % Specialization succeeded - call it
-         writeln("specialization path."),
-         call(Goal)
-    ; fun(Fun),
-      (current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail) ),
-      \+ ( current_op(_, _, Fun), Arity =< 2 )
-      -> % Direct call
-         append(AVs, [Out], Args),
-         Goal =.. [Fun|Args],
-         call(Goal)
-    ; % Not callable as predicate - use reduce for proper handling
-      reduce([Fun|AVs], Out)
-    ).
-
-% Runtime type-aware call: checks for type information at runtime and handles argument translation
-% This is used by the compiler to defer type-aware translation to runtime
-runtime_call_typed(Fun, OrigArgs, Out) :-
-    % Check for type information at runtime
+runtime_call(Fun, ArgExprs, Out) :-
+    % Query for type declaration at runtime (when atom space is populated)
     findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-    ( TypeChains \= [], TypeChains = [TypeChain|_]
-      -> % Type information exists - translate arguments according to their types
-         TypeChain = [->|Xs],
-         append(ArgTypes, [_OutType], Xs),
-         translate_args_by_type_runtime(OrigArgs, ArgTypes, AVs),
-         runtime_call(Fun, AVs, Out)
-    ; % No type information - evaluate all arguments and call
-      translate_args_runtime(OrigArgs, AVs),
-      runtime_call(Fun, AVs, Out)
+    ( TypeChains = [TypeChain|_],
+      TypeChain = [->|Xs],
+      append(ArgTypes, [OutType], Xs)
+      -> % HAS TYPE DECLARATION - evaluate args according to their types
+         format('[DEBUG] runtime_call(~w, ~w) with types: ~w~n', [Fun, ArgExprs, ArgTypes]),
+         maplist({ArgExprs}/[Type,Expr,AV]>>(
+             ( Type == 'Expression'
+               -> format('  [DEBUG] Expr type: keeping ~w as Expression~n', [Expr]), AV = Expr
+               ; % Evaluate the expression
+                 format('  [DEBUG] Evaluating ~w (type=~w)~n', [Expr, Type]),
+                 translate_expr(Expr, true, Goals, AVTmp),
+                 call_goals(Goals),
+                 format('    [DEBUG] Evaluated to: ~w~n', [AVTmp]),
+                 % Type check if not %Undefined% or Atom
+                 ( (Type == '%Undefined%' ; Type == 'Atom')
+                   -> format('    [DEBUG] Skipping type check (%Undefined%/Atom)~n'), AV = AVTmp
+                   ; format('    [DEBUG] Type checking ~w against ~w~n', [AVTmp, Type]),
+                     ( ('get-type'(AVTmp, Type) *-> true ; 'get-metatype'(AVTmp, Type))
+                       -> format('    [DEBUG] Type check PASSED~n'), AV = AVTmp
+                       ; format('    [DEBUG] Type check FAILED~n'), fail
+                     )
+                 )
+             )
+         ), ArgTypes, ArgExprs, AVs),
+         format('[DEBUG] Evaluated args: ~w~n', [AVs]),
+         % Now call the function with properly evaluated arguments
+         length(AVs, N),
+         Arity is N + 1,
+         ( maybe_specialize_call(Fun, AVs, OutTmp, Goal)
+           -> format('[DEBUG] Specialization succeeded~n'), writeln("specialization path."), call(Goal)
+         ; fun(Fun),
+           (current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail)),
+           \+ ( current_op(_, _, Fun), Arity =< 2 )
+           -> format('[DEBUG] Direct call: ~w/~w~n', [Fun, Arity]),
+              append(AVs, [OutTmp], Args), Goal =.. [Fun|Args],
+              format('[DEBUG] Calling: ~w~n', [Goal]),
+              call(Goal),
+              format('[DEBUG] Call succeeded, result: ~w~n', [OutTmp])
+         ; format('[DEBUG] Fallback to reduce~n'),
+           reduce([Fun|AVs], OutTmp),
+           format('[DEBUG] Reduce result: ~w~n', [OutTmp])
+         ),
+         % Type check output if needed
+         format('[DEBUG] Output type check: OutType=~w, OutTmp=~w~n', [OutType, OutTmp]),
+         ( (OutType == '%Undefined%' ; OutType == 'Atom')
+           -> format('[DEBUG] Skipping output type check~n'), Out = OutTmp
+           ; format('[DEBUG] Checking output type~n'),
+             ( ('get-type'(OutTmp, OutType) *-> true ; 'get-metatype'(OutTmp, OutType))
+               -> format('[DEBUG] Output type check PASSED~n'), Out = OutTmp
+               ; format('[DEBUG] Output type check FAILED~n'), fail
+             )
+         ),
+         format('[DEBUG] Final output: ~w~n', [Out])
+    ; % NO TYPE DECLARATION - evaluate all args (default behavior)
+      maplist({ArgExprs}/[Expr,AV]>>(
+          translate_expr(Expr, true, Goals, AV),
+          call_goals(Goals)
+      ), ArgExprs, AVs),
+      % Call function (same logic as typed path)
+      length(AVs, N),
+      Arity is N + 1,
+      ( maybe_specialize_call(Fun, AVs, Out, Goal)
+        -> writeln("specialization path."), call(Goal)
+      ; fun(Fun),
+        (current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail)),
+        \+ ( current_op(_, _, Fun), Arity =< 2 )
+        -> append(AVs, [Out], Args), Goal =.. [Fun|Args], call(Goal)
+      ; reduce([Fun|AVs], Out)
+      )
     ).
-
-% Helper: translate arguments at runtime according to their types
-translate_args_by_type_runtime([], _, []) :- !.
-translate_args_by_type_runtime([A|As], [T|Ts], [AV|AVs]) :-
-    ( T == 'Expression' 
-      -> % Keep as data - don't evaluate
-         AV = A
-    ; % Evaluate the argument
-      translate_expr_to_conj(A, true, Conj, AV),
-      call(Conj)
-    ),
-    translate_args_by_type_runtime(As, Ts, AVs).
-
-% Helper: translate/evaluate all arguments at runtime (no type info)
-translate_args_runtime([], []) :- !.
-translate_args_runtime([A|As], [AV|AVs]) :-
-    translate_expr_to_conj(A, true, Conj, AV),
-    call(Conj),
-    translate_args_runtime(As, AVs).
-
-% Runtime type-aware call for partial applications
-runtime_call_typed_partial(Fun, Bound, NewArgs, Out) :-
-    append(Bound, NewArgs, AllArgs),
-    runtime_call_typed(Fun, AllArgs, Out).
 
 %Type function call generation, returns function call plus typechecks for input and output:
 typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal) :-

--- a/src/translator_backup3.pl
+++ b/src/translator_backup3.pl
@@ -324,101 +324,32 @@ translate_expr([H0|T0], Execute, Goals, Out) :-
         %--- Automatic 'smart' dispatch, translator deciding when to create a predicate call, data list, or dynamic dispatch: ---
         ; translate_args(T, Execute, GsT, AVs),
           append(GsH, GsT, Inner),
-          % Old implementation
-          % smart_dispatch(HV, T, Execute, GsH, GsT, Inner, AVs, Goals, Out)).
-          ( Execute ->
-              smart_dispatch_execute(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-            ; smart_dispatch_compile(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-          )
-        ).
-
-%Automatic 'smart' dispatch implementation:
-smart_dispatch(HV, T, Execute, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; (Execute ->
-          build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
-        ; append(Inner, [runtime_call(Fun, AVs, Out)], Goals)
-        )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> ( Execute -> Out = [HV|AVs], Goals = Inner
-                                        ; append(Inner, [runtime_call(HV, AVs, Out)], Goals) )
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=true (interpreter mode):
-smart_dispatch_execute(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; length(AllAVs, N),
-        Arity is N + 1,
-        ( maybe_specialize_call(Fun, AllAVs, Out, Goal)
-          -> % Specialization succeeded during execution - use it
-             append(Inner, [Goal], Goals)
-        ; ( current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail) ),
-          \+ ( current_op(_, _, Fun), Arity =< 2 )
-          -> % Direct call during execution
-             append(AllAVs, [Out], Args),
-             Goal =.. [Fun|Args],
-             append(Inner, [Goal], Goals)
-        ; Out = partial(Fun, AllAVs),
-          append(Inner, [], Goals)
-        )
-      )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> Out = [HV|AVs], Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(true, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=false (compiler mode):
-smart_dispatch_compile(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Check for function call that might need type-aware handling:
-  ( atom(HV)
-    -> % Use runtime_call_typed to defer type checking to runtime
-       % Pass original unevaluated arguments T, not translated AVs
-       append(GsH, [runtime_call_typed(HV, T, Out)], Goals)
-  ; compound(HV), HV = partial(Fun, Bound)
-    -> % Partial application - append bound args to new args at runtime
-       append(GsH, [runtime_call_typed_partial(Fun, Bound, T, Out)], Goals)
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(false, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
+          %Known function => direct call:
+          ( is_list(AVs), 
+            ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
+            ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
+            ) % Check for type definition [:,HV,TypeChain]
+            -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
+               ( TypeChains \= []
+                 -> maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
+                            typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
+                    disj_list(Branches, Disj),
+                    Goals = [Disj]
+              ; (Execute ->
+                  build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
+                ; append(Inner, [runtime_call(Fun, AVs, Out)], Goals)
+                )
+          %Literals (numbers, strings, etc.), known non-function atom => data:
+          ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
+                                           Goals = Inner
+          ; atom(HV), \+ fun(HV) -> ( Execute -> Out = [HV|AVs], Goals = Inner
+                                                ; append(Inner, [runtime_call(HV, AVs, Out)], Goals) )
+          %Plain data list: evaluate inner fun-sublists
+          ; is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
+                           append(Inner, Gd, Goals),
+                           Out = [HV1|AVs]
+          %Unknown head (var/compound) => runtime dispatch:
+          ; append(Inner, [reduce([HV|AVs], Out)], Goals) )).
 
 %Generate actual function call or partial if arity not complete:
 build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :- 
@@ -457,46 +388,6 @@ runtime_call(Fun, AVs, Out) :-
     ; % Not callable as predicate - use reduce for proper handling
       reduce([Fun|AVs], Out)
     ).
-
-% Runtime type-aware call: checks for type information at runtime and handles argument translation
-% This is used by the compiler to defer type-aware translation to runtime
-runtime_call_typed(Fun, OrigArgs, Out) :-
-    % Check for type information at runtime
-    findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-    ( TypeChains \= [], TypeChains = [TypeChain|_]
-      -> % Type information exists - translate arguments according to their types
-         TypeChain = [->|Xs],
-         append(ArgTypes, [_OutType], Xs),
-         translate_args_by_type_runtime(OrigArgs, ArgTypes, AVs),
-         runtime_call(Fun, AVs, Out)
-    ; % No type information - evaluate all arguments and call
-      translate_args_runtime(OrigArgs, AVs),
-      runtime_call(Fun, AVs, Out)
-    ).
-
-% Helper: translate arguments at runtime according to their types
-translate_args_by_type_runtime([], _, []) :- !.
-translate_args_by_type_runtime([A|As], [T|Ts], [AV|AVs]) :-
-    ( T == 'Expression' 
-      -> % Keep as data - don't evaluate
-         AV = A
-    ; % Evaluate the argument
-      translate_expr_to_conj(A, true, Conj, AV),
-      call(Conj)
-    ),
-    translate_args_by_type_runtime(As, Ts, AVs).
-
-% Helper: translate/evaluate all arguments at runtime (no type info)
-translate_args_runtime([], []) :- !.
-translate_args_runtime([A|As], [AV|AVs]) :-
-    translate_expr_to_conj(A, true, Conj, AV),
-    call(Conj),
-    translate_args_runtime(As, AVs).
-
-% Runtime type-aware call for partial applications
-runtime_call_typed_partial(Fun, Bound, NewArgs, Out) :-
-    append(Bound, NewArgs, AllArgs),
-    runtime_call_typed(Fun, AllArgs, Out).
 
 %Type function call generation, returns function call plus typechecks for input and output:
 typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal) :-

--- a/src/translator_latest_garbage.pl
+++ b/src/translator_latest_garbage.pl
@@ -322,103 +322,44 @@ translate_expr([H0|T0], Execute, Goals, Out) :-
                                                       ; Out = ['Error', Exception])),
           append(Inner, [Goal], Goals)
         %--- Automatic 'smart' dispatch, translator deciding when to create a predicate call, data list, or dynamic dispatch: ---
-        ; translate_args(T, Execute, GsT, AVs),
-          append(GsH, GsT, Inner),
-          % Old implementation
-          % smart_dispatch(HV, T, Execute, GsH, GsT, Inner, AVs, Goals, Out)).
-          ( Execute ->
-              smart_dispatch_execute(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-            ; smart_dispatch_compile(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-          )
-        ).
-
-%Automatic 'smart' dispatch implementation:
-smart_dispatch(HV, T, Execute, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; (Execute ->
-          build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
-        ; append(Inner, [runtime_call(Fun, AVs, Out)], Goals)
-        )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> ( Execute -> Out = [HV|AVs], Goals = Inner
-                                        ; append(Inner, [runtime_call(HV, AVs, Out)], Goals) )
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=true (interpreter mode):
-smart_dispatch_execute(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; length(AllAVs, N),
-        Arity is N + 1,
-        ( maybe_specialize_call(Fun, AllAVs, Out, Goal)
-          -> % Specialization succeeded during execution - use it
-             append(Inner, [Goal], Goals)
-        ; ( current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail) ),
-          \+ ( current_op(_, _, Fun), Arity =< 2 )
-          -> % Direct call during execution
-             append(AllAVs, [Out], Args),
-             Goal =.. [Fun|Args],
-             append(Inner, [Goal], Goals)
-        ; Out = partial(Fun, AllAVs),
-          append(Inner, [], Goals)
-        )
-      )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> Out = [HV|AVs], Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(true, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=false (compiler mode):
-smart_dispatch_compile(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Check for function call that might need type-aware handling:
-  ( atom(HV)
-    -> % Use runtime_call_typed to defer type checking to runtime
-       % Pass original unevaluated arguments T, not translated AVs
-       append(GsH, [runtime_call_typed(HV, T, Out)], Goals)
-  ; compound(HV), HV = partial(Fun, Bound)
-    -> % Partial application - append bound args to new args at runtime
-       append(GsH, [runtime_call_typed_partial(Fun, Bound, T, Out)], Goals)
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(false, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
+        ; ( ( atom(HV), fun(HV), Fun = HV, IsPartial = false
+            ; compound(HV), HV = partial(Fun, Bound), IsPartial = true
+            )
+            % Check for type definition FIRST (before translating args!)
+            -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
+               ( TypeChains \= []
+                 -> % HAS TYPES - use typed translation (same as before)
+                    maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
+                            typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
+                    disj_list(Branches, Disj),
+                    Goals = [Disj]
+               ; % NO TYPES - translate args normally and dispatch
+                 translate_args(T, Execute, GsT, AVs),
+                 ( IsPartial -> append(Bound, AVs, AllAVs) ; AllAVs = AVs ),
+                 append(GsH, GsT, Inner),
+                 (Execute
+                   -> build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals)
+                   ; Goals = [runtime_call(Fun, T, Out)]  % Pass expressions, not values!
+                 )
+               )
+          ; % Not a known function - translate args for remaining branches
+            translate_args(T, Execute, GsT, AVs),
+            append(GsH, GsT, Inner),
+            ( % Literals (numbers, strings, etc.)
+              ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs], Goals = Inner
+            ; % Non-function atom
+              atom(HV), \+ fun(HV) -> ( Execute
+                                         -> Out = [HV|AVs], Goals = Inner
+                                         ; Goals = [runtime_call(HV, T, Out)]  % Pass expressions!
+                                       )
+            ; % Data list
+              is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
+                             append(Inner, Gd, Goals),
+                             Out = [HV1|AVs]
+            ; % Unknown head (var/compound) => runtime dispatch
+              append(Inner, [reduce([HV|AVs], Out)], Goals)
+            )
+          )).
 
 %Generate actual function call or partial if arity not complete:
 build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :- 
@@ -437,66 +378,82 @@ build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :-
       append(Inner, Extra, Goals)
     ).
 
-% Runtime call helper: replicates what build_call_or_partial does when Execute=true
-% This allows compiled programs to benefit from specialization
+% Runtime call helper: accepts unevaluated expressions and evaluates them according to type declarations
+% This allows compiled programs to respect Expression types and other type annotations
 % Falls back to reduce for edge cases (partial applications, non-callables, etc.)
-runtime_call(Fun, AVs, Out) :-
-    length(AVs, N),
-    Arity is N + 1,
-    ( maybe_specialize_call(Fun, AVs, Out, Goal)
-      -> % Specialization succeeded - call it
-         writeln("specialization path."),
-         call(Goal)
-    ; fun(Fun),
-      (current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail) ),
-      \+ ( current_op(_, _, Fun), Arity =< 2 )
-      -> % Direct call
-         append(AVs, [Out], Args),
-         Goal =.. [Fun|Args],
-         call(Goal)
-    ; % Not callable as predicate - use reduce for proper handling
-      reduce([Fun|AVs], Out)
-    ).
-
-% Runtime type-aware call: checks for type information at runtime and handles argument translation
-% This is used by the compiler to defer type-aware translation to runtime
-runtime_call_typed(Fun, OrigArgs, Out) :-
-    % Check for type information at runtime
+runtime_call(Fun, ArgExprs, Out) :-
+    % Query for type declaration at runtime (when atom space is populated)
     findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-    ( TypeChains \= [], TypeChains = [TypeChain|_]
-      -> % Type information exists - translate arguments according to their types
-         TypeChain = [->|Xs],
-         append(ArgTypes, [_OutType], Xs),
-         translate_args_by_type_runtime(OrigArgs, ArgTypes, AVs),
-         runtime_call(Fun, AVs, Out)
-    ; % No type information - evaluate all arguments and call
-      translate_args_runtime(OrigArgs, AVs),
-      runtime_call(Fun, AVs, Out)
+    ( TypeChains = [TypeChain|_],
+      TypeChain = [->|Xs],
+      append(ArgTypes, [OutType], Xs)
+      -> % HAS TYPE DECLARATION - evaluate args according to their types
+         format('[DEBUG] runtime_call(~w, ~w) with types: ~w~n', [Fun, ArgExprs, ArgTypes]),
+         maplist({ArgExprs}/[Type,Expr,AV]>>(
+             ( Type == 'Expression'
+               -> format('  [DEBUG] Expr type: keeping ~w as Expression~n', [Expr]), AV = Expr
+               ; % Evaluate the expression
+                 format('  [DEBUG] Evaluating ~w (type=~w)~n', [Expr, Type]),
+                 translate_expr(Expr, true, Goals, AVTmp),
+                 call_goals(Goals),
+                 format('    [DEBUG] Evaluated to: ~w~n', [AVTmp]),
+                 % Type check if not %Undefined% or Atom
+                 ( (Type == '%Undefined%' ; Type == 'Atom')
+                   -> format('    [DEBUG] Skipping type check (%Undefined%/Atom)~n'), AV = AVTmp
+                   ; format('    [DEBUG] Type checking ~w against ~w~n', [AVTmp, Type]),
+                     ( ('get-type'(AVTmp, Type) *-> true ; 'get-metatype'(AVTmp, Type))
+                       -> format('    [DEBUG] Type check PASSED~n'), AV = AVTmp
+                       ; format('    [DEBUG] Type check FAILED~n'), fail
+                     )
+                 )
+             )
+         ), ArgTypes, ArgExprs, AVs),
+         format('[DEBUG] Evaluated args: ~w~n', [AVs]),
+         % Now call the function with properly evaluated arguments
+         length(AVs, N),
+         Arity is N + 1,
+         ( maybe_specialize_call(Fun, AVs, OutTmp, Goal)
+           -> format('[DEBUG] Specialization succeeded~n'), writeln("specialization path."), call(Goal)
+         ; fun(Fun),
+           (current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail)),
+           \+ ( current_op(_, _, Fun), Arity =< 2 )
+           -> format('[DEBUG] Direct call: ~w/~w~n', [Fun, Arity]),
+              append(AVs, [OutTmp], Args), Goal =.. [Fun|Args],
+              format('[DEBUG] Calling: ~w~n', [Goal]),
+              call(Goal),
+              format('[DEBUG] Call succeeded, result: ~w~n', [OutTmp])
+         ; format('[DEBUG] Fallback to reduce~n'),
+           reduce([Fun|AVs], OutTmp),
+           format('[DEBUG] Reduce result: ~w~n', [OutTmp])
+         ),
+         % Type check output if needed
+         format('[DEBUG] Output type check: OutType=~w, OutTmp=~w~n', [OutType, OutTmp]),
+         ( (OutType == '%Undefined%' ; OutType == 'Atom')
+           -> format('[DEBUG] Skipping output type check~n'), Out = OutTmp
+           ; format('[DEBUG] Checking output type~n'),
+             ( ('get-type'(OutTmp, OutType) *-> true ; 'get-metatype'(OutTmp, OutType))
+               -> format('[DEBUG] Output type check PASSED~n'), Out = OutTmp
+               ; format('[DEBUG] Output type check FAILED~n'), fail
+             )
+         ),
+         format('[DEBUG] Final output: ~w~n', [Out])
+    ; % NO TYPE DECLARATION - evaluate all args (default behavior)
+      maplist({ArgExprs}/[Expr,AV]>>(
+          translate_expr(Expr, true, Goals, AV),
+          call_goals(Goals)
+      ), ArgExprs, AVs),
+      % Call function (same logic as typed path)
+      length(AVs, N),
+      Arity is N + 1,
+      ( maybe_specialize_call(Fun, AVs, Out, Goal)
+        -> writeln("specialization path."), call(Goal)
+      ; fun(Fun),
+        (current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail)),
+        \+ ( current_op(_, _, Fun), Arity =< 2 )
+        -> append(AVs, [Out], Args), Goal =.. [Fun|Args], call(Goal)
+      ; reduce([Fun|AVs], Out)
+      )
     ).
-
-% Helper: translate arguments at runtime according to their types
-translate_args_by_type_runtime([], _, []) :- !.
-translate_args_by_type_runtime([A|As], [T|Ts], [AV|AVs]) :-
-    ( T == 'Expression' 
-      -> % Keep as data - don't evaluate
-         AV = A
-    ; % Evaluate the argument
-      translate_expr_to_conj(A, true, Conj, AV),
-      call(Conj)
-    ),
-    translate_args_by_type_runtime(As, Ts, AVs).
-
-% Helper: translate/evaluate all arguments at runtime (no type info)
-translate_args_runtime([], []) :- !.
-translate_args_runtime([A|As], [AV|AVs]) :-
-    translate_expr_to_conj(A, true, Conj, AV),
-    call(Conj),
-    translate_args_runtime(As, AVs).
-
-% Runtime type-aware call for partial applications
-runtime_call_typed_partial(Fun, Bound, NewArgs, Out) :-
-    append(Bound, NewArgs, AllArgs),
-    runtime_call_typed(Fun, AllArgs, Out).
 
 %Type function call generation, returns function call plus typechecks for input and output:
 typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal) :-

--- a/src/translator_new.pl
+++ b/src/translator_new.pl
@@ -322,103 +322,44 @@ translate_expr([H0|T0], Execute, Goals, Out) :-
                                                       ; Out = ['Error', Exception])),
           append(Inner, [Goal], Goals)
         %--- Automatic 'smart' dispatch, translator deciding when to create a predicate call, data list, or dynamic dispatch: ---
-        ; translate_args(T, Execute, GsT, AVs),
-          append(GsH, GsT, Inner),
-          % Old implementation
-          % smart_dispatch(HV, T, Execute, GsH, GsT, Inner, AVs, Goals, Out)).
-          ( Execute ->
-              smart_dispatch_execute(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-            ; smart_dispatch_compile(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-          )
-        ).
-
-%Automatic 'smart' dispatch implementation:
-smart_dispatch(HV, T, Execute, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; (Execute ->
-          build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
-        ; append(Inner, [runtime_call(Fun, AVs, Out)], Goals)
-        )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> ( Execute -> Out = [HV|AVs], Goals = Inner
-                                        ; append(Inner, [runtime_call(HV, AVs, Out)], Goals) )
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=true (interpreter mode):
-smart_dispatch_execute(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; length(AllAVs, N),
-        Arity is N + 1,
-        ( maybe_specialize_call(Fun, AllAVs, Out, Goal)
-          -> % Specialization succeeded during execution - use it
-             append(Inner, [Goal], Goals)
-        ; ( current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail) ),
-          \+ ( current_op(_, _, Fun), Arity =< 2 )
-          -> % Direct call during execution
-             append(AllAVs, [Out], Args),
-             Goal =.. [Fun|Args],
-             append(Inner, [Goal], Goals)
-        ; Out = partial(Fun, AllAVs),
-          append(Inner, [], Goals)
-        )
-      )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> Out = [HV|AVs], Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(true, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=false (compiler mode):
-smart_dispatch_compile(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Check for function call that might need type-aware handling:
-  ( atom(HV)
-    -> % Use runtime_call_typed to defer type checking to runtime
-       % Pass original unevaluated arguments T, not translated AVs
-       append(GsH, [runtime_call_typed(HV, T, Out)], Goals)
-  ; compound(HV), HV = partial(Fun, Bound)
-    -> % Partial application - append bound args to new args at runtime
-       append(GsH, [runtime_call_typed_partial(Fun, Bound, T, Out)], Goals)
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(false, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
+        ; ( ( atom(HV), fun(HV), Fun = HV, IsPartial = false
+            ; compound(HV), HV = partial(Fun, Bound), IsPartial = true
+            )
+            % Check for type definition FIRST (before translating args!)
+            -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
+               ( TypeChains \= []
+                 -> % HAS TYPES - use typed translation (same as before)
+                    maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
+                            typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
+                    disj_list(Branches, Disj),
+                    Goals = [Disj]
+               ; % NO TYPES - translate args normally and dispatch
+                 translate_args(T, Execute, GsT, AVs),
+                 ( IsPartial -> append(Bound, AVs, AllAVs) ; AllAVs = AVs ),
+                 append(GsH, GsT, Inner),
+                 (Execute
+                   -> build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals)
+                   ; Goals = [runtime_call(Fun, T, Out)]  % Pass expressions, not values!
+                 )
+               )
+          ; % Not a known function - translate args for remaining branches
+            translate_args(T, Execute, GsT, AVs),
+            append(GsH, GsT, Inner),
+            ( % Literals (numbers, strings, etc.)
+              ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs], Goals = Inner
+            ; % Non-function atom
+              atom(HV), \+ fun(HV) -> ( Execute
+                                         -> Out = [HV|AVs], Goals = Inner
+                                         ; Goals = [runtime_call(HV, T, Out)]  % Pass expressions!
+                                       )
+            ; % Data list
+              is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
+                             append(Inner, Gd, Goals),
+                             Out = [HV1|AVs]
+            ; % Unknown head (var/compound) => runtime dispatch
+              append(Inner, [reduce([HV|AVs], Out)], Goals)
+            )
+          )).
 
 %Generate actual function call or partial if arity not complete:
 build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :- 
@@ -437,66 +378,68 @@ build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :-
       append(Inner, Extra, Goals)
     ).
 
-% Runtime call helper: replicates what build_call_or_partial does when Execute=true
-% This allows compiled programs to benefit from specialization
+% Runtime call helper: accepts unevaluated expressions and evaluates them according to type declarations
+% This allows compiled programs to respect Expression types and other type annotations
 % Falls back to reduce for edge cases (partial applications, non-callables, etc.)
-runtime_call(Fun, AVs, Out) :-
-    length(AVs, N),
-    Arity is N + 1,
-    ( maybe_specialize_call(Fun, AVs, Out, Goal)
-      -> % Specialization succeeded - call it
-         writeln("specialization path."),
-         call(Goal)
-    ; fun(Fun),
-      (current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail) ),
-      \+ ( current_op(_, _, Fun), Arity =< 2 )
-      -> % Direct call
-         append(AVs, [Out], Args),
-         Goal =.. [Fun|Args],
-         call(Goal)
-    ; % Not callable as predicate - use reduce for proper handling
-      reduce([Fun|AVs], Out)
-    ).
-
-% Runtime type-aware call: checks for type information at runtime and handles argument translation
-% This is used by the compiler to defer type-aware translation to runtime
-runtime_call_typed(Fun, OrigArgs, Out) :-
-    % Check for type information at runtime
+runtime_call(Fun, ArgExprs, Out) :-
+    % Query for type declaration at runtime (when atom space is populated)
     findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-    ( TypeChains \= [], TypeChains = [TypeChain|_]
-      -> % Type information exists - translate arguments according to their types
-         TypeChain = [->|Xs],
-         append(ArgTypes, [_OutType], Xs),
-         translate_args_by_type_runtime(OrigArgs, ArgTypes, AVs),
-         runtime_call(Fun, AVs, Out)
-    ; % No type information - evaluate all arguments and call
-      translate_args_runtime(OrigArgs, AVs),
-      runtime_call(Fun, AVs, Out)
+    ( TypeChains = [TypeChain|_],
+      TypeChain = [->|Xs],
+      append(ArgTypes, [OutType], Xs)
+      -> % HAS TYPE DECLARATION - evaluate args according to their types
+         maplist({ArgExprs}/[Type,Expr,AV]>>(
+             ( Type == 'Expression'
+               -> AV = Expr  % Keep as unevaluated expression
+               ; % Evaluate the expression
+                 translate_expr(Expr, true, Goals, AVTmp),
+                 call_goals(Goals),
+                 % Type check if not %Undefined% or Atom
+                 ( (Type == '%Undefined%' ; Type == 'Atom')
+                   -> AV = AVTmp
+                   ; ( ('get-type'(AVTmp, Type) *-> true ; 'get-metatype'(AVTmp, Type))
+                       -> AV = AVTmp
+                       ; fail  % Type check failed
+                     )
+                 )
+             )
+         ), ArgTypes, ArgExprs, AVs),
+         % Now call the function with properly evaluated arguments
+         length(AVs, N),
+         Arity is N + 1,
+         ( maybe_specialize_call(Fun, AVs, OutTmp, Goal)
+           -> writeln("specialization path."), call(Goal)
+         ; fun(Fun),
+           (current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail)),
+           \+ ( current_op(_, _, Fun), Arity =< 2 )
+           -> append(AVs, [OutTmp], Args), Goal =.. [Fun|Args], call(Goal)
+         ; reduce([Fun|AVs], OutTmp)
+         ),
+         % Type check output if needed
+         ( (OutType == '%Undefined%' ; OutType == 'Atom')
+           -> Out = OutTmp
+           ; ( ('get-type'(OutTmp, OutType) *-> true ; 'get-metatype'(OutTmp, OutType))
+               -> Out = OutTmp
+               ; fail  % Output type check failed
+             )
+         )
+    ; % NO TYPE DECLARATION - evaluate all args (default behavior)
+      maplist({ArgExprs}/[Expr,AV]>>(
+          translate_expr(Expr, true, Goals, AV),
+          call_goals(Goals)
+      ), ArgExprs, AVs),
+      % Call function (same logic as typed path)
+      length(AVs, N),
+      Arity is N + 1,
+      ( maybe_specialize_call(Fun, AVs, Out, Goal)
+        -> writeln("specialization path."), call(Goal)
+      ; fun(Fun),
+        (current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail)),
+        \+ ( current_op(_, _, Fun), Arity =< 2 )
+        -> append(AVs, [Out], Args), Goal =.. [Fun|Args], call(Goal)
+      ; reduce([Fun|AVs], Out)
+      )
     ).
-
-% Helper: translate arguments at runtime according to their types
-translate_args_by_type_runtime([], _, []) :- !.
-translate_args_by_type_runtime([A|As], [T|Ts], [AV|AVs]) :-
-    ( T == 'Expression' 
-      -> % Keep as data - don't evaluate
-         AV = A
-    ; % Evaluate the argument
-      translate_expr_to_conj(A, true, Conj, AV),
-      call(Conj)
-    ),
-    translate_args_by_type_runtime(As, Ts, AVs).
-
-% Helper: translate/evaluate all arguments at runtime (no type info)
-translate_args_runtime([], []) :- !.
-translate_args_runtime([A|As], [AV|AVs]) :-
-    translate_expr_to_conj(A, true, Conj, AV),
-    call(Conj),
-    translate_args_runtime(As, AVs).
-
-% Runtime type-aware call for partial applications
-runtime_call_typed_partial(Fun, Bound, NewArgs, Out) :-
-    append(Bound, NewArgs, AllArgs),
-    runtime_call_typed(Fun, AllArgs, Out).
 
 %Type function call generation, returns function call plus typechecks for input and output:
 typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal) :-

--- a/src/translator_old.pl
+++ b/src/translator_old.pl
@@ -324,101 +324,32 @@ translate_expr([H0|T0], Execute, Goals, Out) :-
         %--- Automatic 'smart' dispatch, translator deciding when to create a predicate call, data list, or dynamic dispatch: ---
         ; translate_args(T, Execute, GsT, AVs),
           append(GsH, GsT, Inner),
-          % Old implementation
-          % smart_dispatch(HV, T, Execute, GsH, GsT, Inner, AVs, Goals, Out)).
-          ( Execute ->
-              smart_dispatch_execute(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-            ; smart_dispatch_compile(HV, T, GsH, GsT, Inner, AVs, Goals, Out)
-          )
-        ).
-
-%Automatic 'smart' dispatch implementation:
-smart_dispatch(HV, T, Execute, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; (Execute ->
-          build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
-        ; append(Inner, [runtime_call(Fun, AVs, Out)], Goals)
-        )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> ( Execute -> Out = [HV|AVs], Goals = Inner
-                                        ; append(Inner, [runtime_call(HV, AVs, Out)], Goals) )
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=true (interpreter mode):
-smart_dispatch_execute(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Known function => direct call:
-  ( is_list(AVs), 
-    ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
-    ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
-    ) % Check for type definition [:,HV,TypeChain]
-    -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-       ( TypeChains \= []
-         -> maplist({Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                    typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
-            disj_list(Branches, Disj),
-            Goals = [Disj]
-      ; length(AllAVs, N),
-        Arity is N + 1,
-        ( maybe_specialize_call(Fun, AllAVs, Out, Goal)
-          -> % Specialization succeeded during execution - use it
-             append(Inner, [Goal], Goals)
-        ; ( current_predicate(Fun/Arity) ; catch(arity(Fun, Arity), _, fail) ),
-          \+ ( current_op(_, _, Fun), Arity =< 2 )
-          -> % Direct call during execution
-             append(AllAVs, [Out], Args),
-             Goal =.. [Fun|Args],
-             append(Inner, [Goal], Goals)
-        ; Out = partial(Fun, AllAVs),
-          append(Inner, [], Goals)
-        )
-      )
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  ; atom(HV), \+ fun(HV) -> Out = [HV|AVs], Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(true, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
-
-%Automatic 'smart' dispatch specialized for Execute=false (compiler mode):
-smart_dispatch_compile(HV, T, GsH, _GsT, Inner, AVs, Goals, Out) :-
-  %Check for function call that might need type-aware handling:
-  ( atom(HV)
-    -> % Use runtime_call_typed to defer type checking to runtime
-       % Pass original unevaluated arguments T, not translated AVs
-       append(GsH, [runtime_call_typed(HV, T, Out)], Goals)
-  ; compound(HV), HV = partial(Fun, Bound)
-    -> % Partial application - append bound args to new args at runtime
-       append(GsH, [runtime_call_typed_partial(Fun, Bound, T, Out)], Goals)
-  %Literals (numbers, strings, etc.), known non-function atom => data:
-  ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
-                                   Goals = Inner
-  %Plain data list: evaluate inner fun-sublists
-  ; is_list(HV) -> eval_data_term(false, HV, Gd, HV1),
-                   append(Inner, Gd, Goals),
-                   Out = [HV1|AVs]
-  %Unknown head (var/compound) => runtime dispatch:
-  ; append(Inner, [reduce([HV|AVs], Out)], Goals) ).
+          %Known function => direct call:
+          ( is_list(AVs), 
+            ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
+            ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
+            ) % Check for type definition [:,HV,TypeChain]
+            -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
+               ( TypeChains \= []
+                 -> maplist({Execute,Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
+                            typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
+                    disj_list(Branches, Disj),
+                    Goals = [Disj]
+              ; (Execute ->
+                  build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
+                ; append(Inner, [runtime_call(Fun, AVs, Out)], Goals)
+                )
+          %Literals (numbers, strings, etc.), known non-function atom => data:
+          ; ( atomic(HV), \+ atom(HV) ) -> Out = [HV|AVs],
+                                           Goals = Inner
+          ; atom(HV), \+ fun(HV) -> ( Execute -> Out = [HV|AVs], Goals = Inner
+                                                ; append(Inner, [runtime_call(HV, AVs, Out)], Goals) )
+          %Plain data list: evaluate inner fun-sublists
+          ; is_list(HV) -> eval_data_term(Execute, HV, Gd, HV1),
+                           append(Inner, Gd, Goals),
+                           Out = [HV1|AVs]
+          %Unknown head (var/compound) => runtime dispatch:
+          ; append(Inner, [reduce([HV|AVs], Out)], Goals) )).
 
 %Generate actual function call or partial if arity not complete:
 build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :- 
@@ -457,46 +388,6 @@ runtime_call(Fun, AVs, Out) :-
     ; % Not callable as predicate - use reduce for proper handling
       reduce([Fun|AVs], Out)
     ).
-
-% Runtime type-aware call: checks for type information at runtime and handles argument translation
-% This is used by the compiler to defer type-aware translation to runtime
-runtime_call_typed(Fun, OrigArgs, Out) :-
-    % Check for type information at runtime
-    findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-    ( TypeChains \= [], TypeChains = [TypeChain|_]
-      -> % Type information exists - translate arguments according to their types
-         TypeChain = [->|Xs],
-         append(ArgTypes, [_OutType], Xs),
-         translate_args_by_type_runtime(OrigArgs, ArgTypes, AVs),
-         runtime_call(Fun, AVs, Out)
-    ; % No type information - evaluate all arguments and call
-      translate_args_runtime(OrigArgs, AVs),
-      runtime_call(Fun, AVs, Out)
-    ).
-
-% Helper: translate arguments at runtime according to their types
-translate_args_by_type_runtime([], _, []) :- !.
-translate_args_by_type_runtime([A|As], [T|Ts], [AV|AVs]) :-
-    ( T == 'Expression' 
-      -> % Keep as data - don't evaluate
-         AV = A
-    ; % Evaluate the argument
-      translate_expr_to_conj(A, true, Conj, AV),
-      call(Conj)
-    ),
-    translate_args_by_type_runtime(As, Ts, AVs).
-
-% Helper: translate/evaluate all arguments at runtime (no type info)
-translate_args_runtime([], []) :- !.
-translate_args_runtime([A|As], [AV|AVs]) :-
-    translate_expr_to_conj(A, true, Conj, AV),
-    call(Conj),
-    translate_args_runtime(As, AVs).
-
-% Runtime type-aware call for partial applications
-runtime_call_typed_partial(Fun, Bound, NewArgs, Out) :-
-    append(Bound, NewArgs, AllArgs),
-    runtime_call_typed(Fun, AllArgs, Out).
 
 %Type function call generation, returns function call plus typechecks for input and output:
 typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal) :-

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,7 @@
 run_test() {
     f="$1"
     echo "Running $f"
+    # output=$(sh run.sh --compiler "$f" | grep "is " | grep " should ")
     output=$(sh run.sh "$f" | grep "is " | grep " should ")
     echo "$output" | grep -q "❌"
     fail=$?
@@ -25,7 +26,7 @@ pidfile="/tmp/metta_pid_map.$$"
 
 for f in ./examples/*.metta; do
     base=$(basename "$f")
-    case "$base" in repl.metta|llm_cities.metta|torch.metta|greedy_chess.metta|git_import2.metta)
+    case "$base" in repl.metta|llm_cities.metta|torch.metta|greedy_chess.metta|git_import2.metta|matespacefast.metta|matespace.metta|matespace2.metta|he_minimalmetta.metta|invertpeanoplus.metta)
         continue ;;
     esac
     run_test "$f" &


### PR DESCRIPTION
PeTTa currently cannot be used as a transpiler because it does not output the generated Prolog clauses when translating MeTTa code. It also always executes all goals, which is not what we want when running it as a compiler. This PR fixes that:

- [x] Modified `load_metta_file` and other clauses to return the generated Prolog program in addition or instead of the execution results.
- [x] Added new runtime option to disable MeTTa code execution and refactored `process_form` to use it.
- [x] Modified the `filereader` module to take into account the already existing runtime option `silent` and disable the debug messages when interpreting/compiling.
- [x] Removed ad-hoc option parsing in `fileloader.pl` and introduced a more principled CLI using the `optparse` library. PeTTa has now two modes of operation: compiler and interpreter.
- [x] Generated 'add-atom' clauses for all MeTTa sexprs when compiling MeTTa programs.
- [x] Add runtime clauses to generated output
- [x] Modified `translate_expr` to print the results of each runnable. This is achieved by optionally adding a write clause at the end of each runnable body. This is only done for top-level MeTTa forms and whenever we are in compiler mode, not when interpreting MeTTa programs the usual way.
- [ ] Make compiled clauses dynamic (we need this to fully support MeTTa).
- [ ] Run all tests in compiled mode?