### PR TITLE
Fix duplicate execution for typed overloads with identical signatures

### DIFF
--- a/src/translator.pl
+++ b/src/translator.pl
@@ -301,9 +301,10 @@ translate_expr([H0|T0], Goals, Out) :-
             ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
             ) % Check for type definition [:,HV,TypeChain]
             -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-               ( TypeChains \= []
+               list_to_set(TypeChains, UniqueTypeChains),
+               ( UniqueTypeChains \= []
                  -> maplist({Fun,T,GsH,IsPartial,Bound,Out}/[TypeChain,BranchGoal]>>(
-                            typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), TypeChains, Branches),
+                            typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchGoal)), UniqueTypeChains, Branches),
                     disj_list(Branches, Disj),
                     Goals = [Disj]
               ; build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))


### PR DESCRIPTION
This PR fixes a dispatch bug where typed function calls could execute multiple times when the same type signature was declared more than once.

In typed dispatch, all type chains for a function were collected and converted into OR branches. If duplicate signatures existed, duplicate branches were generated, and each branch could succeed, causing repeated execution.

Example repro
Given:

(: bin (-> Number))
(= (bin) 1)
(: bin (-> Number))
(= (bin) 2)
!(bin)

Returns
1
2
1
2
Typed dispatch created two equivalent branches for the same signature, so both clauses could run.

Root cause
In [translator.pl:308](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html), typed dispatch used all matched type chains directly, without deduplicating identical signatures.

Fix
Deduplicate collected type chains before branch generation.
Generate typed branches only from unique type chains.
Keep existing behavior unchanged for genuinely different overload signatures.
Implemented in:

[translator.pl:309](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Behavior change
Before: duplicate identical type definitions could trigger duplicate function execution.
After: identical type chains collapse to a single dispatch branch, preventing duplicate execution.