### PR TITLE
Fix import! to throw error when target file/library is not found

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -1,6 +1,6 @@
 %%%%%%%%%% Dependencies %%%%%%%%%%
-library(X, Path) :- library_path(Base), atomic_list_concat([Base, '/', X], Path).
-library(X, Y, Path) :- library_path(Base), atomic_list_concat([Base, '/../', X, '/', Y], Path).
+library(X, Path) :- library_path(Base), atomic_list_concat([Base, '/', X], Path), !.
+library(X, Y, Path) :- library_path(Base), atomic_list_concat([Base, '/../', X, '/', Y], Path), !.
 :- prolog_load_context(directory, Source),
    directory_file_path(Source, '..', Parent),
    directory_file_path(Parent, 'lib', LibPath),
@@ -269,19 +269,24 @@ retractPredicate(_, false).
 ensure_metta_ext(Path, Path) :- file_name_extension(_, metta, Path), !.
 ensure_metta_ext(Path, PathWithExt) :- file_name_extension(Path, metta, PathWithExt).
 
-'import!'(Space, File, true) :- catch(importer_helper(Space, File), _, fail).
+'import!'(Space, File, true) :- importer_helper(Space, File).
 importer_helper(Space, File) :- atom_string(File, SFile),
                                 working_dir(Base),
                                 ( file_name_extension(ModPath, 'py', SFile)
                                   -> absolute_file_name(SFile, Path, [relative_to(Base)]),
                                      file_directory_name(Path, Dir),
                                      file_base_name(ModPath, ModuleName),
-                                     py_call(sys:path:append(Dir), _),
-                                     py_call(builtins:'__import__'(ModuleName), _)
-                                   ; ( Path = SFile ; atomic_list_concat([Base, '/', SFile], Path) ),
-                                     ensure_metta_ext(Path, PathWithExt),
-                                     exists_file(PathWithExt), !,
-                                     load_metta_file(PathWithExt, _, Space) ).
+                                     ( catch(use_module(library(janus)), _, fail)
+                                       -> py_call(sys:path:append(Dir), _),
+                                          py_call(builtins:'__import__'(ModuleName), _)
+                                        ; throw(error(existence_error(source_sink, library(janus)),
+                                                      context('import!', File))) )
+                                    ; ( Path = SFile ; atomic_list_concat([Base, '/', SFile], Path) ),
+                                      ensure_metta_ext(Path, PathWithExt),
+                                      exists_file(PathWithExt), !,
+                                      load_metta_file(PathWithExt, _, Space)
+                                  ; throw(error(existence_error(source_sink, File),
+                                                context('import!', File))) ).
 
 :- dynamic translator_rule/1.
 'add-translator-rule!'(HV, true) :- ( translator_rule(HV)


### PR DESCRIPTION
## Description

### Summary
This PR changes the import execution path so missing files/library targets raise a real Prolog exception instead of failing by backtracking to `false`.

### Root Cause
`import!` previously swallowed all importer failures:

```prolog
'import!'(Space, File, true) :- catch(importer_helper(Space, File), _, fail).
```

### Implementation Details
The change removes blanket exception swallowing and makes failure explicit.

`import!` now directly delegates to `importer_helper/2`:

```prolog
'import!'(Space, File, true) :- importer_helper(Space, File).
```

resolution now follows:

1. Build candidate path (`Path`)
2. Normalize extension with `ensure_metta_ext/2` -> `PathWithExt`
3. If file exists, load via `load_metta_file/3`
4. Otherwise, throw:

```prolog
throw(error(existence_error(source_sink, File),
            context('import!', File)))
```

This yields standard SWI-Prolog error semantics and is catch-compatible.

For valid imports, behavior is unchanged:
     path resolution
     `.metta` extension normalization
     loading into the target space

#### Before
     Missing import: silent fail (`false`)

#### After
    Missing import: explicit runtime error (`existence_error(source_sink, ...)`)
    `catch` receives a concrete error term and can handle/report it

### Validation
    `!(catch (import! ...missing...))` returns structured `Error(...)` value as expected.
