### PR TITLE
Add match-count builtin: count matches without materializing results

### DIFF
--- a/examples/match_count.metta
+++ b/examples/match_count.metta
@@ -1,0 +1,19 @@
+; Tests for the match-count builtin.
+; match-count counts the number of atoms in a space that match a pattern,
+; without materializing the result set — useful on very large knowledge bases
+; where `(length (collapse (match ...)))` would exhaust the stack.
+
+(parent alice bob)
+(parent alice carol)
+(parent bob dave)
+(parent bob eve)
+(parent carol frank)
+
+; 1) Counts every atom matching the pattern.
+!(test (match-count &self (parent $p $c)) 5)
+
+; 2) Counts only atoms matching a bound pattern (alice's direct children).
+!(test (match-count &self (parent alice $c)) 2)
+
+; 3) Returns 0 when nothing matches, without failing.
+!(test (match-count &self (parent zelda $c)) 0)

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -297,7 +297,7 @@ register_fun(N) :- (fun(N) -> true ; assertz(fun(N))).
                           'first-from-pair', 'second-from-pair', 'car-atom', 'cdr-atom', 'unique-atom', 'alpha-unique-atom',
                           repr, repra, parse, 'println!', 'readln!', test, assert, 'mm2-exec', atom_concat, atom_chars, copy_term, term_hash,
                           foldl, first, last, append, length, 'size-atom', sort, msort, member, 'is-member', 'exclude-item', list_to_set, maplist, eval, reduce, 'import!',
-                          'add-atom', 'remove-atom', 'get-atoms', match, 'is-var', 'is-expr', 'is-space', 'get-mettatype',
+                          'add-atom', 'remove-atom', 'get-atoms', match, 'match-count', 'is-var', 'is-expr', 'is-space', 'get-mettatype',
                           decons, 'decons-atom', 'py-call', 'get-type', 'get-metatype', '=alpha', concat, sread, cons, reverse,
                           '#+','#-','#*','#div','#//','#mod','#min','#max','#<','#>','#=','#\\=','set_hook',
                           'union-atom', 'cons-atom', 'intersection-atom', 'subtraction-atom', 'index-atom', id,

--- a/src/spaces.pl
+++ b/src/spaces.pl
@@ -62,8 +62,13 @@ match(Space, [Rel|PatArgs], OutPattern, Result) :- Term =.. [Space, Rel | PatArg
                                                    \+ cyclic_term(OutPattern),
                                                    Result = OutPattern.
 
+%Count matches without materializing results  
+'match-count'(Space, Pattern, Count) :-  
+    aggregate_all(count, match(Space, Pattern, _, _), Count).
+
 %Get all atoms in space, irregard of arity:
 'get-atoms'(Space, Pattern) :- current_predicate(Space/Arity),
                                functor(Head, Space, Arity),
                                clause(Head, true),
                                Head =.. [Space | Pattern].
+


### PR DESCRIPTION
### Summary

This PR adds a match-count builtin that efficiently counts the number of atoms matching a pattern without materializing the entire result set. It addresses a critical performance issue where counting matches using (length (collapse (match ...))) would cause stack overflow on large knowledge bases.

### Problem

Counting how many atoms in a space match a pattern is currently done via (length (collapse (match <space> <pattern> <pattern>))), which builds a Prolog list of every match. On large in-RAM AtomSpaces this exhausts the stack long before the count is needed — the caller only wants a number, not the results themselves.

### Solution

Implemented match-count using aggregate_all/3 which is failure-driven and keeps a single counter — no list is built. The new function:

- Uses constant memory regardless of result size
- Reuses the existing match/4 implementation
- Returns the count directly without materializing matches

### Implementation

```
match-count(Space, Pattern, Count) :-  
    aggregate_all(count, match(Space, Pattern, _, _), Count).
```

The function is added to src/spaces.pl and registered in src/metta.pl to enable MeTTa calls.

### Testing

Added comprehensive tests in examples/match_count.metta covering:

Full pattern count: (match-count &self (parent $p $c)) => 5
Bound pattern count: (match-count &self (parent alice $c)) => 2
Zero matches: (match-count &self (parent zelda $c)) => 0

Test with:
`sh run.sh ./examples/match_count.metta  `
# Expect: three lines each ending in ✅

### Files changed
src/spaces.pl — defines match-count/3 as a wrapper over aggregate_all(count, match(...), Count)
src/metta.pl — registers match-count in the function list
examples/match_count.metta — three test cases