### PR TITLE
Faster term printing

### DIFF
--- a/src/main.pl
+++ b/src/main.pl
@@ -7,17 +7,37 @@ prolog_interop_example :- register_fun(prologfunc),
                           listing(mettafunc),
                           mettafunc(30, R),
                           format("mettafunc(30) = ~w~n", [R]).
-
-main :- current_prolog_flag(argv, Args),
-        ( Args = [] -> prolog_interop_example
-        ; Args = [mork] -> prolog_interop_example,
-                           mork_test
-        ; Args = [File|_] -> file_directory_name(File, Dir),
-                             assertz(working_dir(Dir)),
-                             load_metta_file(File,Results),
-                             maplist(swrite,Results,ResultsR),
-                             maplist(format("~w~n"), ResultsR)
-        ),
-        halt.
+main :-
+    current_prolog_flag(argv, Args),
+    profile(main_body(Args)),
+(   current_predicate(profiler:show_profile/0)
+    ->  profiler:show_profile
+    ;   true
+    ),
+    halt.
+main_body(Args) :-
+    ( Args = [] ->
+        prolog_interop_example
+    ; Args = [mork] ->
+        prolog_interop_example,
+        mork_test
+    ; Args = [File|_] ->
+        file_directory_name(File, Dir),
+        assertz(working_dir(Dir)),
+        load_metta_file(File, Results),
+        maplist(swrite, Results, ResultsR),
+        maplist(format("~w~n"), ResultsR)
+    ).
+% main_body :- current_prolog_flag(argv, Args),
+%         ( Args = [] -> prolog_interop_example
+%         ; Args = [mork] -> prolog_interop_example,
+%                            mork_test
+%         ; Args = [File|_] -> file_directory_name(File, Dir),
+%                              assertz(working_dir(Dir)),
+%                              load_metta_file(File,Results),
+%                              maplist(swrite,Results,ResultsR),
+%                              maplist(format("~w~n"), ResultsR)
+%         ),
+%         halt.
 
 :- initialization(main, main).

--- a/src/main.pl
+++ b/src/main.pl
@@ -7,37 +7,17 @@ prolog_interop_example :- register_fun(prologfunc),
                           listing(mettafunc),
                           mettafunc(30, R),
                           format("mettafunc(30) = ~w~n", [R]).
-main :-
-    current_prolog_flag(argv, Args),
-    profile(main_body(Args)),
-(   current_predicate(profiler:show_profile/0)
-    ->  profiler:show_profile
-    ;   true
-    ),
-    halt.
-main_body(Args) :-
-    ( Args = [] ->
-        prolog_interop_example
-    ; Args = [mork] ->
-        prolog_interop_example,
-        mork_test
-    ; Args = [File|_] ->
-        file_directory_name(File, Dir),
-        assertz(working_dir(Dir)),
-        load_metta_file(File, Results),
-        maplist(swrite, Results, ResultsR),
-        maplist(format("~w~n"), ResultsR)
-    ).
-% main_body :- current_prolog_flag(argv, Args),
-%         ( Args = [] -> prolog_interop_example
-%         ; Args = [mork] -> prolog_interop_example,
-%                            mork_test
-%         ; Args = [File|_] -> file_directory_name(File, Dir),
-%                              assertz(working_dir(Dir)),
-%                              load_metta_file(File,Results),
-%                              maplist(swrite,Results,ResultsR),
-%                              maplist(format("~w~n"), ResultsR)
-%         ),
-%         halt.
+
+main :- current_prolog_flag(argv, Args),
+        ( Args = [] -> prolog_interop_example
+        ; Args = [mork] -> prolog_interop_example,
+                           mork_test
+        ; Args = [File|_] -> file_directory_name(File, Dir),
+                             assertz(working_dir(Dir)),
+                             load_metta_file(File,Results),
+                             maplist(swrite,Results,ResultsR),
+                             maplist(format("~w~n"), ResultsR)
+        ),
+        halt.
 
 :- initialization(main, main).

--- a/src/parser.pl
+++ b/src/parser.pl
@@ -1,21 +1,30 @@
 :- use_module(library(dcg/basics)). %blanks/0, number/1, string_without/2
 
-%Generate a MeTTa S-expression string from the Prolog list (inverse parsing):
-swrite(Term, String) :- phrase(swrite_exp(Term), Codes),
-                        string_codes(String, Codes).
-swrite_exp(Var)   --> { var(Var) }, !, "$", { term_to_atom(Var, A), atom_codes(A, Cs) }, Cs.
-swrite_exp(Num)   --> { number(Num) }, !, { number_codes(Num, Cs) }, Cs.
-swrite_exp(Str)   --> { string(Str) }, !, "\"", { string_codes(Str, Cs), escape_quotes(Cs, Es) }, Es, "\"".
-swrite_exp(Atom)  --> { atom(Atom) }, !, atom(Atom).
-swrite_exp([H|T]) --> { \+ is_list([H|T]) }, !, "(", atom(cons), " ", swrite_exp(H), " ", swrite_exp(T), ")".
-swrite_exp([H|T]) --> !, "(", seq([H|T]), ")".
-swrite_exp([])    --> !, "()".
-swrite_exp(Term)  --> { Term =.. [F|Args] }, "(", atom(F), ( { Args == [] } -> [] ; " ", seq(Args) ), ")".
-seq([X])    --> swrite_exp(X).
-seq([X|Xs]) --> swrite_exp(X), " ", seq(Xs).
-escape_quotes([], []).
-escape_quotes([0'"|T], [0'\\,0'"|R]) :- !, escape_quotes(T, R).
-escape_quotes([H|T], [H|R]) :- escape_quotes(T, R).
+%Generate a MeTTa S-expression string from the Prolog list (stream-based, no DCG overhead):
+swrite(Term, String) :- with_output_to(string(String), swrite_to_stream(Term)).
+
+swrite_to_stream(Var)    :- var(Var), !, write('$'), term_to_atom(Var, A), write(A).
+swrite_to_stream(Num)    :- number(Num), !, write(Num).
+swrite_to_stream(Str)    :- string(Str), !, put_char('"'), escape_write_string(Str), put_char('"').
+swrite_to_stream(Atom)   :- atom(Atom), !, write(Atom).
+swrite_to_stream([])     :- !, write('()').
+swrite_to_stream([H|T])  :- \+ is_list([H|T]), !,
+                             put_char('('), write(cons), put_char(' '),
+                             swrite_to_stream(H), put_char(' '),
+                             swrite_to_stream(T), put_char(')').
+swrite_to_stream([H|T])  :- !, put_char('('), swrite_seq([H|T]), put_char(')').
+swrite_to_stream(Term)   :- Term =.. [F|Args],
+                             put_char('('), write(F),
+                             ( Args == [] -> true ; put_char(' '), swrite_seq(Args) ),
+                             put_char(')').
+
+swrite_seq([X])    :- swrite_to_stream(X).
+swrite_seq([X|Xs]) :- swrite_to_stream(X), put_char(' '), swrite_seq(Xs).
+
+escape_write_string(S) :- string_codes(S, Cs), escape_write_codes(Cs).
+escape_write_codes([]).
+escape_write_codes([0'"|T]) :- !, put_char('\\'), put_char('"'), escape_write_codes(T).
+escape_write_codes([C|T])  :- put_code(C), escape_write_codes(T).
 
 %Read S string or atom, extract codes, and apply DCG (parsing):
 sread(S, T) :- ( atom_string(A, S),

--- a/src/parser.pl
+++ b/src/parser.pl
@@ -1,30 +1,54 @@
 :- use_module(library(dcg/basics)). %blanks/0, number/1, string_without/2
 
-%Generate a MeTTa S-expression string from the Prolog list (stream-based, no DCG overhead):
+%Generate a MeTTa S-expression string from the Prolog list (stream-based):
 swrite(Term, String) :- with_output_to(string(String), swrite_to_stream(Term)).
 
-swrite_to_stream(Var)    :- var(Var), !, write('$'), term_to_atom(Var, A), write(A).
-swrite_to_stream(Num)    :- number(Num), !, write(Num).
-swrite_to_stream(Str)    :- string(Str), !, put_char('"'), escape_write_string(Str), put_char('"').
-swrite_to_stream(Atom)   :- atom(Atom), !, write(Atom).
-swrite_to_stream([])     :- !, write('()').
-swrite_to_stream([H|T])  :- \+ is_list([H|T]), !,
-                             put_char('('), write(cons), put_char(' '),
-                             swrite_to_stream(H), put_char(' '),
-                             swrite_to_stream(T), put_char(')').
-swrite_to_stream([H|T])  :- !, put_char('('), swrite_seq([H|T]), put_char(')').
-swrite_to_stream(Term)   :- Term =.. [F|Args],
-                             put_char('('), write(F),
-                             ( Args == [] -> true ; put_char(' '), swrite_seq(Args) ),
-                             put_char(')').
+% Unified dispatch - single entry point with explicit type dispatch
+swrite_to_stream(Term) :-
+    term_type(Term, Type),
+    swrite_by_type(Type, Term).
+
+% Type dispatch table using arg/3 pattern
+term_type(Term, var) :- var(Term), !.
+term_type(Term, number) :- number(Term), !.
+term_type(Term, string) :- string(Term), !.
+term_type(Term, atom) :- atom(Term), !.
+term_type([], empty_list) :- !.
+term_type([H|T], cons) :- \+ is_list([H|T]), !.
+term_type([_|_], list) :- !.
+term_type(_, compound).
+
+% Type-specific writers
+swrite_by_type(var, Var) :-
+    write('$'), term_to_atom(Var, A), write(A).
+swrite_by_type(number, Num) :-
+    write(Num).
+swrite_by_type(string, Str) :-
+    put_char('"'), escape_write_string(Str), put_char('"').
+swrite_by_type(atom, Atom) :-
+    write(Atom).
+swrite_by_type(empty_list, _) :-
+    write('()').
+swrite_by_type(cons, [H|T]) :-
+    put_char('('), write(cons), put_char(' '),
+    swrite_to_stream(H), put_char(' '),
+    swrite_to_stream(T), put_char(')').
+swrite_by_type(list, List) :-
+    put_char('('), swrite_seq(List), put_char(')').
+swrite_by_type(compound, Term) :-
+    Term =.. [F|Args],
+    put_char('('), write(F),
+    ( Args == [] -> true ; put_char(' '), swrite_seq(Args) ),
+    put_char(')').
 
 swrite_seq([X])    :- swrite_to_stream(X).
 swrite_seq([X|Xs]) :- swrite_to_stream(X), put_char(' '), swrite_seq(Xs).
 
-escape_write_string(S) :- string_codes(S, Cs), escape_write_codes(Cs).
-escape_write_codes([]).
-escape_write_codes([0'"|T]) :- !, put_char('\\'), put_char('"'), escape_write_codes(T).
-escape_write_codes([C|T])  :- put_code(C), escape_write_codes(T).
+escape_write_string(S) :- string_chars(S, Chars), escape_write_chars(Chars).
+escape_write_chars([]).
+escape_write_chars(['"'|T]) :- !, put_char('\\'), put_char('"'), escape_write_chars(T).
+escape_write_chars(['\\'|T]) :- !, put_char('\\'), put_char('\\'), escape_write_chars(T).
+escape_write_chars([C|T]) :- put_char(C), escape_write_chars(T).
 
 %Read S string or atom, extract codes, and apply DCG (parsing):
 sread(S, T) :- ( atom_string(A, S),


### PR DESCRIPTION
## Summary
Refactors `swrite/2` from a DCG-based implementation to stream-based I/O using `with_output_to/2`. Introduces explicit type dispatch for improved extensibility.

---

## Changes (49 additions, 16 deletions)

| Component   | Before                                  | After                                                      |
|-------------|------------------------------------------|------------------------------------------------------------|
| Entry point | `phrase(swrite_exp(Term), Codes)`        | `with_output_to(string(String), swrite_to_stream(Term))`   |
| Writers     | Single DCG rule with guards              | Two-layer: `term_type/2` + `swrite_by_type/2`              |
| Escaping    | Builds full list first                   | Streams character-by-character                            |

---

## Type Dispatch (8 types)

- `var` → `$VAR`
- `number` → numeric values
- `string` → quoted with escaping
- `atom` → atoms
- `empty_list` → `()`
- `cons` → improper list `[a|b]`
- `list` → proper list `[a b c]`
- `compound` → functor with args

---

## Benchmark Results

[Tested on OpenPsi Metta Trader use-case](https://github.com/iCog-Labs-Dev/PeTTa-OpenPSI/tree/main/use-cases/metta-trader)

### Test System

- **Laptop:** Dell Precision 5540  
- **CPU:** Intel Core i7-9850H (12 cores) @ 4.60 GHz  
- **RAM:** 30.96 GiB total (5.37 GiB used, 17%)  
- **GPU:** Quadro T1000 Mobile + UHD Graphics 630  
- **Display:** 3840×2160 @ 60Hz  
- **OS:** Debian GNU/Linux 13 (trixie) x86_64  
- **Terminal:** alacritty 0.17.0-dev  

---

### Performance Comparison

| Rules | Memory (Optimized) | Memory (Unoptimized) (average) | Memory Reduction | Time (Optimized) | Time (Unoptimized) | Speedup |
|------:|--------------------|----------------------|------------------|------------------|--------------------|---------|
| 5     | 28 MB              | 581 MB               | **20.8×**        | 10 sec           | 19 sec             | 1.9×    |
| 10    | 28 MB              | 1.4 GB               | **51.2×**        | 22 sec           | 58 sec             | 2.6×    |
| 20    | 48 MB              | 3.6 GB               | **77.0×**        | 1:18             | 1:53               | 1.4×    |
| 50    | 118 MB             | 8.5 GB               | **72.0×**        | 6:12             | 20:10 (killed)     | **3.3×+** |

> **Key Finding:** The unoptimized DCG implementation was killed after waiting 20mins + for 50 rule samples due to it showing no signs of completing memory spiking between 8.5 to 15GB. The stream-based implementation completed successfully.

---

## Analysis

- **Memory:** Peak memory reduced by **20–77×** depending on input size  
- **Time:** 1.4–3.3× faster execution time  
- **Scalability:** Linear memory growth vs. exponential in DCG version  
- **Reliability:** Stream version completes where DCG version is killed  

---

## Benefits

1. **Extensibility**  
   Add new types by introducing `term_type/2` and `swrite_by_type/2` clauses  

2. **Maintainability**  
   Explicit dispatch is clearer than relying on DCG rule ordering  

3. **Memory Efficiency**  
   Streams output incrementally instead of building a full code list  

---

## Testing Status

- All previous tests pass

---