### PR TITLE
change to company URL for MettaWamJam link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Please see the [jupyter-petta-kernel README](https://github.com/trueagi-io/jupyt
 
 A HTTP server running MeTTa code is also available:
 
-**Repository:** [MettaWamJam](https://github.com/jazzbox35/MettaWamJam)
+**Repository:** [MettaWamJam](https://github.com/trueagi-io/MettaWamJam)
 
 Please see the [MettaWamJam README](https://github.com/jazzbox35/MettaWamJam/blob/main/README.md) for detailed installation instructions and usage.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A HTTP server running MeTTa code is also available:
 
 **Repository:** [MettaWamJam](https://github.com/trueagi-io/MettaWamJam)
 
-Please see the [MettaWamJam README](https://github.com/jazzbox35/MettaWamJam/blob/main/README.md) for detailed installation instructions and usage.
+Please see the [MettaWamJam README](https://github.com/trueagi-io/MettaWamJam/blob/main/README.md) for detailed installation instructions and usage.
 
 ### MeTTa in WASM
 


### PR DESCRIPTION
This PR changes the link to the PeTTa docker from my own repo to the official company repo.