### PR TITLE
Add is-ground function as a counter-part to is-var

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -189,6 +189,7 @@ get_type_candidate(X, T) :- match('&self', [':',X,T], T, _).
 'get-metatype'(X, 'Symbol') :- atom(X), !.            % e.g., a
 
 'is-var'(A,R) :- var(A) -> R=true ; R=false.
+'is-ground'(A,R) :- ground(A) -> R=true ; R=false.
 'is-expr'(A,R) :- is_list(A) -> R=true ; R=false.
 'is-space'(A,R) :- atom(A), atom_concat('&', _, A) -> R=true ; R=false.
 
@@ -304,7 +305,7 @@ register_fun(N) :- (fun(N) -> true ; assertz(fun(N))).
                           'first-from-pair', 'second-from-pair', 'car-atom', 'cdr-atom', 'unique-atom', 'alpha-unique-atom',
                           repr, repra, parse, 'println!', 'readln!', test, assert, 'mm2-exec', atom_concat, atom_chars, copy_term, term_hash,
                           foldl, first, last, append, length, 'size-atom', sort, msort, member, 'is-member', 'is-alpha-member', 'exclude-item', list_to_set, maplist, eval, reduce, 'import!',
-                          'add-atom', 'remove-atom', 'get-atoms', match, 'is-var', 'is-expr', 'is-space', 'get-mettatype',
+                          'add-atom', 'remove-atom', 'get-atoms', match, 'is-var', 'is-ground', 'is-expr', 'is-space', 'get-mettatype',
                           decons, 'decons-atom', 'py-call', 'get-type', 'get-metatype', '=alpha', concat, sread, cons, reverse,
                           '#+','#-','#*','#div','#//','#mod','#min','#max','#<','#>','#=','#\\=','set_hook',
                           'union-atom', 'cons-atom', 'intersection-atom', 'subtraction-atom', 'index-atom', id,


### PR DESCRIPTION
- Add is-ground/1 predicate for checking if an expression is a ground expression. A complement to the already existing is-var/1 predicate