### PR TITLE
Add type-casting Support

### DIFF
--- a/examples/he_types.metta
+++ b/examples/he_types.metta
@@ -2,10 +2,11 @@
 
 !(test (is-function (-> Atom Atom)) True)
 !(test (is-function Atom) False)
-;TODO:
-;(: type1 Type)
-;!(type-cast A type1 &self)
-;!(type-cast 1 type1 &self)
+(: type1 Type)
+!(type-cast A type1 &self)
+!(type-cast 1 type1 &self)
+!(test (get-type A) type1)
+!(test (get-type 1) type1)
 !(test (match-types Atom Atom "Matched!" "Didn't match") "Matched!")
 !(test (match-types Atom Number "Matched!" "Didn't match") "Didn't match")
 !(test (first-from-pair (A B)) A)

--- a/examples/types.metta
+++ b/examples/types.metta
@@ -6,7 +6,7 @@
 (: x Letter)
 (: x Buchstabe)
 
-!(test (get-type $a) $z)
+!(test (get-type $a) %Undefined%)
 !(test (get-type a) A)
 !(test (get-type b) B)
 !(test (get-type c) %Undefined%)

--- a/lib/lib_he.metta
+++ b/lib/lib_he.metta
@@ -84,4 +84,7 @@
    (match-types $type1 $type2 True $value))
 
 ;Type casting
-(= (type-cast $x $t $space) (add-atom $space (: $x $t)))
+(= (type-cast $x $t $space)
+   (let* (($removed (remove-atom $space (: $x $_)))
+        ($added (add-atom $space (: $x $t))))
+     $added))

--- a/lib/lib_he.metta
+++ b/lib/lib_he.metta
@@ -82,3 +82,6 @@
 
 (= (match-type-or $value $type1 $type2)
    (match-types $type1 $type2 True $value))
+
+;Type casting
+(= (type-cast $x $t $space) (add-atom $space (: $x $t)))

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -169,6 +169,7 @@ get_function_type([F|Args], T) :- nonvar(F), match('&self', [':',F,[->|Ts]], _, 
 
 :- dynamic 'get-type'/2.
 'get-type'(X, T) :- (get_type_candidate(X, T) *-> true ; T = '%Undefined%' ).
+get_type_candidate(X, T) :- match('&self', [':',X,T], T, _), !.
 get_type_candidate(X, 'Number')   :- number(X), !.
 get_type_candidate(X, _) :- var(X), !.
 get_type_candidate(X, 'String')   :- string(X), !.
@@ -178,7 +179,6 @@ get_type_candidate(X, T) :- get_function_type(X,T).
 get_type_candidate(X, T) :- \+ get_function_type(X, _),
                             is_list(X),
                             maplist('get-type', X, T).
-get_type_candidate(X, T) :- match('&self', [':',X,T], T, _).
 'get-metatype'(X, 'Variable') :- var(X), !.
 'get-metatype'(X, 'Grounded') :- number(X), !.
 'get-metatype'(X, 'Grounded') :- string(X), !.

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -168,17 +168,17 @@ get_function_type([F|Args], T) :- nonvar(F), match('&self', [':',F,[->|Ts]], _, 
                                   maplist('get-type',Args,As).
 
 :- dynamic 'get-type'/2.
-'get-type'(X, T) :- (get_type_candidate(X, T) *-> true ; T = '%Undefined%' ).
-get_type_candidate(X, T) :- ground(X), match('&self', [':',X,T], T, _), !.
-get_type_candidate(X, 'Number')   :- number(X), !.
-get_type_candidate(X, _) :- var(X), !.
-get_type_candidate(X, 'String')   :- string(X), !.
-get_type_candidate(true, 'Bool')  :- !.
-get_type_candidate(false, 'Bool') :- !.
-get_type_candidate(X, T) :- get_function_type(X,T).
-get_type_candidate(X, T) :- \+ get_function_type(X, _),
-                            is_list(X),
-                            maplist('get-type', X, T).
+'get-type'(X, T) :- ((ground(X), match('&self', [':',X,T], T, _)) *-> true ; get_type_candidate_inferred(X, T)).
+'get-type'(X, '%Undefined%') :- \+ get_type_candidate_inferred(X, _), \+ (ground(X), match('&self', [':',X,_], _, _)).
+get_type_candidate_inferred(X, 'Number')   :- number(X), !.
+get_type_candidate_inferred(X, '%Undefined%') :- var(X), !.
+get_type_candidate_inferred(X, 'String')   :- string(X), !.
+get_type_candidate_inferred(true, 'Bool')  :- !.
+get_type_candidate_inferred(false, 'Bool') :- !.
+get_type_candidate_inferred(X, T) :- get_function_type(X,T).
+get_type_candidate_inferred(X, T) :- \+ get_function_type(X, _), is_list(X), maplist('get-type', X, T).
+
+get_type_candidate(X, T) :- 'get-type'(X, T).
 'get-metatype'(X, 'Variable') :- var(X), !.
 'get-metatype'(X, 'Grounded') :- number(X), !.
 'get-metatype'(X, 'Grounded') :- string(X), !.

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -169,7 +169,7 @@ get_function_type([F|Args], T) :- nonvar(F), match('&self', [':',F,[->|Ts]], _, 
 
 :- dynamic 'get-type'/2.
 'get-type'(X, T) :- (get_type_candidate(X, T) *-> true ; T = '%Undefined%' ).
-get_type_candidate(X, T) :- match('&self', [':',X,T], T, _), !.
+get_type_candidate(X, T) :- ground(X), match('&self', [':',X,T], T, _), !.
 get_type_candidate(X, 'Number')   :- number(X), !.
 get_type_candidate(X, _) :- var(X), !.
 get_type_candidate(X, 'String')   :- string(X), !.

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -343,7 +343,7 @@ typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchG
     translate_args_by_type(T, ArgTypes, GsT2, AVsTmp0),
     ( IsPartial -> append(Bound, AVsTmp0, AVsTmp) ; AVsTmp = AVsTmp0 ),
     append(GsH, GsT2, InnerTmp),
-    ( (OutType == '%Undefined%' ; OutType == 'Atom')
+    ( (var(OutType) ; OutType == '%Undefined%' ; OutType == 'Atom')
        -> Extra = [] ; Extra = [('get-type'(Out, OutType) *-> true ; 'get-metatype'(Out, OutType))] ),
     build_call_or_partial(Fun, AVsTmp, Out, InnerTmp, Extra, GoalsList),
     goals_list_to_conj(GoalsList, BranchGoal).
@@ -354,7 +354,7 @@ translate_args_by_type([], _, [], []) :- !.
 translate_args_by_type([A|As], [T|Ts], GsOut, [AV|AVs]) :-
                       ( T == 'Expression' -> AV = A, GsA = []
                                            ; translate_expr(A, GsA1, AV),
-                                             ( (T == '%Undefined%' ; T == 'Atom')
+                                             ( (var(T) ; T == '%Undefined%' ; T == 'Atom')
                                                -> GsA = GsA1
                                                 ; append(GsA1, [('get-type'(AV, T) *-> true ; 'get-metatype'(AV, T))], GsA))),
                                              translate_args_by_type(As, Ts, GsRest, AVs),


### PR DESCRIPTION
This PR implements type-casting support and wires type checking by the tests after casting. 

- Adds a `type-cast` helper function in `lib_he.metta`, enables a `get-types` invocation/call in `he_types.metta` after type is casted by preferring space-registered types via match in `metta.pl`.  simply old type declarations are overridden in the space when a new type is cast.