### PR TITLE
Zar/get type variable undefined

### DIFF
--- a/examples/types.metta
+++ b/examples/types.metta
@@ -6,7 +6,7 @@
 (: x Letter)
 (: x Buchstabe)
 
-!(test (get-type $a) $z)
+!(test (get-type $a) %Undefined%)
 !(test (get-type a) A)
 !(test (get-type b) B)
 !(test (get-type c) %Undefined%)

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -163,7 +163,7 @@ get_function_type([F|Args], T) :- nonvar(F), match('&self', [':',F,[->|Ts]], _, 
 :- dynamic 'get-type'/2.
 'get-type'(X, T) :- (get_type_candidate(X, T) *-> true ; T = '%Undefined%' ).
 get_type_candidate(X, 'Number')   :- number(X), !.
-get_type_candidate(X, _) :- var(X), !.
+get_type_candidate(X, '%Undefined%') :- var(X), !.
 get_type_candidate(X, 'String')   :- string(X), !.
 get_type_candidate(true, 'Bool')  :- !.
 get_type_candidate(false, 'Bool') :- !.


### PR DESCRIPTION
Small fix to how get-type handles varables thanks to Codex 5.5.

---

 Fixes `get-type` on unbound variables so it returns `%Undefined%` instead of leaking a fresh logic variable.

 Previously, this clause in `src/metta.pl`:

  ```prolog
  get_type_candidate(X, _) :- var(X), !.
```
  succeeded while leaving the output type unbound. Because get-type uses committed choice, that success prevented the normal %Undefined% fallback from running. The result was that (get-type $a) could return a fresh variable, and that variable could escape into stored type facts or later unify with concrete types.

Behavioral reproduction can be seen by the following program:
```
; Repro: `(get-type $var)` returns a fresh variable in PeTTa, and that
; variable can escape into a type fact.  The result is branch-order-dependent
; type routing for an atom whose type should be unknown.

(: route-number-first (-> Atom Atom))
(= (route-number-first $x)
   (case (get-type $x)
     ((Number number-route)
      (Bool bool-route)
      (%Undefined% unknown-route))))

(: route-bool-first (-> Atom Atom))
(= (route-bool-first $x)
   (case (get-type $x)
     ((Bool bool-route)
      (Number number-route)
      (%Undefined% unknown-route))))

; Make a type fact whose type is the result of `(get-type $a)`.
; If `(get-type $a)` were `%Undefined%`, `phantom` would route as unknown.
!(let $t (get-type $a)
   (add-atom &self (: phantom $t)))

; Baseline: an undeclared symbol routes as unknown in both branch orders.
!(route-number-first never-declared)
!(route-bool-first never-declared)

; The stored type for `phantom` is a fresh variable, not `%Undefined%`.
!(match &self (: phantom $t) (stored-type-for-phantom $t))

; Bug: the same atom follows different concrete routes depending only on
; branch order.
!(route-number-first phantom)
!(route-bool-first phantom)
```

Before fix:
```
[True]
[unknown-route]
[unknown-route]
[(stored-type-for-phantom $_79752)]
[number-route]
[bool-route]
```

After fix:
```
[True]
[unknown-route]
[unknown-route]
[(stored-type-for-phantom %Undefined%)]
[unknown-route]
[unknown-route]
```
