### PR TITLE
Add alpha-unique that operates on a superposition

### DIFF
--- a/src/translator.pl
+++ b/src/translator.pl
@@ -75,6 +75,8 @@ rewrite_streamops(['trace!', Arg1, Arg2],
                   [progn, ['println!', Arg1], Arg2]).
 rewrite_streamops([unique, Arg],
                   [call, [superpose, ['unique-atom', [collapse, Arg]]]]).
+rewrite_streamops(['alpha-unique', Arg],
+                  [call, [superpose, ['alpha-unique-atom', [collapse, Arg]]]]).
 rewrite_streamops([union, [superpose|A], [superpose|B]],
                   [call, [superpose, ['union-atom', [collapse, [superpose|A]],
                                                     [collapse, [superpose|B]]]]]).


### PR DESCRIPTION
It is like `alpha-unique-atom` but operates on a superposition instead of a tuple.

I did not find it necessary to add tests because `alpha-unique-atom` is already extensively covered.