### PR TITLE
fix: make car-atom/cdr-atom safe on empty or non-lists & support short-circuit operators

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -139,7 +139,8 @@ alpha_list_to_set_assoc([H|T], SeenIn, R) :-
 'size-atom'(List, Size) :- length(List, Size).
 'car-atom'([H|_], H) :- !.
 'car-atom'(_, []).
-'cdr-atom'([_|T], T).
+'cdr-atom'([_|T], T) :- !.
+'cdr-atom'(_, []).
 decons([H|T], [H|[T]]).
 cons(H, T, [H|T]).
 'index-atom'(List, Index, Elem) :- nth0(Index, List, Elem).

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -137,7 +137,8 @@ alpha_list_to_set_assoc([H|T], SeenIn, R) :-
 
 'sort-atom'(List, Sorted) :- msort(List, Sorted).
 'size-atom'(List, Size) :- length(List, Size).
-'car-atom'([H|_], H).
+'car-atom'([H|_], H) :- !.
+'car-atom'(_, []).
 'cdr-atom'([_|T], T).
 decons([H|T], [H|[T]]).
 cons(H, T, [H|T]).

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -174,6 +174,13 @@ translate_expr([H0|T0], Goals, Out) :-
                                                      ; translate_expr(KeyExpr, Gk, Kv),
                                                        translate_case(PairsExpr, Kv, Out, IfGoal, KeyGoal),
                                                        append([GsH, Gk, KeyGoal, [IfGoal]], Goals) )
+        %--- Short-circuit boolean operators ---:
+        ; HV == 'and-then', T = [A, B] -> translate_expr_to_conj(A, ConjA, Av),
+                                           translate_expr_to_conj(B, ConjB, Bv),
+                                           append(GsH, [(ConjA, (Av == true -> (ConjB, Out = Bv) ; Out = false))], Goals)
+        ; HV == 'or-else', T = [A, B] -> translate_expr_to_conj(A, ConjA, Av),
+                                          translate_expr_to_conj(B, ConjB, Bv),
+                                          append(GsH, [(ConjA, (Av == true -> Out = true ; (ConjB, Out = Bv)))], Goals)
         %--- Unification constructs ---:
         ; (HV == let ; HV == chain), T = [Pat, Val, In] -> translate_expr(Pat, Gp, Pv),
                                                            translate_expr(Val, Gv, V),

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -174,13 +174,6 @@ translate_expr([H0|T0], Goals, Out) :-
                                                      ; translate_expr(KeyExpr, Gk, Kv),
                                                        translate_case(PairsExpr, Kv, Out, IfGoal, KeyGoal),
                                                        append([GsH, Gk, KeyGoal, [IfGoal]], Goals) )
-        %--- Short-circuit boolean operators ---:
-        ; HV == and, T = [A, B] -> translate_expr_to_conj(A, ConjA, Av),
-                                    translate_expr_to_conj(B, ConjB, Bv),
-                                    append(GsH, [(ConjA, bool(Av), (Av == true -> (ConjB, bool(Bv), Out = Bv) ; Out = false))], Goals)
-        ; HV == or, T = [A, B] -> translate_expr_to_conj(A, ConjA, Av),
-                                   translate_expr_to_conj(B, ConjB, Bv),
-                                   append(GsH, [(ConjA, bool(Av), (Av == true -> Out = true ; (ConjB, bool(Bv), Out = Bv)))], Goals)
         %--- Unification constructs ---:
         ; (HV == let ; HV == chain), T = [Pat, Val, In] -> translate_expr(Pat, Gp, Pv),
                                                            translate_expr(Val, Gv, V),

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -174,6 +174,13 @@ translate_expr([H0|T0], Goals, Out) :-
                                                      ; translate_expr(KeyExpr, Gk, Kv),
                                                        translate_case(PairsExpr, Kv, Out, IfGoal, KeyGoal),
                                                        append([GsH, Gk, KeyGoal, [IfGoal]], Goals) )
+        %--- Short-circuit boolean operators ---:
+        ; HV == and, T = [A, B] -> translate_expr_to_conj(A, ConjA, Av),
+                                    translate_expr_to_conj(B, ConjB, Bv),
+                                    append(GsH, [(ConjA, bool(Av), (Av == true -> (ConjB, bool(Bv), Out = Bv) ; Out = false))], Goals)
+        ; HV == or, T = [A, B] -> translate_expr_to_conj(A, ConjA, Av),
+                                   translate_expr_to_conj(B, ConjB, Bv),
+                                   append(GsH, [(ConjA, bool(Av), (Av == true -> Out = true ; (ConjB, bool(Bv), Out = Bv)))], Goals)
         %--- Unification constructs ---:
         ; (HV == let ; HV == chain), T = [Pat, Val, In] -> translate_expr(Pat, Gp, Pv),
                                                            translate_expr(Val, Gv, V),


### PR DESCRIPTION
This PR:
Fixes [car-atom & cdr-atom on empty input cases](https://github.com/trueagi-io/PeTTa/issues/182) by making the `car-atom` and `cdr-atom`  return `()` on empty or non-list inputs instead of crashing.

Additionally, Adds `and-then` and `or-else` to preserve the short-circut approach alongside the car-atom and cdr-atom fixes.(i.e e.g if the first operand is False, no need to evalute the second one in the case os `and-then` and if one is true, no need of evaluating the second in the case of `or-else`) .
