### PR TITLE
fix on get-state function

### DIFF
--- a/examples/state.metta
+++ b/examples/state.metta
@@ -2,3 +2,4 @@
 !(test (get-state state) rest)
 !(change-state! state active)
 !(test (get-state state) active)
+!(test (get-state fresh-state) ())

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -239,7 +239,16 @@ assert(Goal, true) :- ( call(Goal) -> true
 %%% States: %%%
 'bind!'(A, ['new-state', B], C) :- 'change-state!'(A, B, C).
 'change-state!'(Var, Value, true) :- nb_setval(Var, Value).
-'get-state'(Var, Value) :- nb_getval(Var, Value).
+'get-state'(Var, Value) :-
+    ( atom(Var) ->
+        ( nb_current(Var, Stored) ->
+            true
+        ;   Stored = [],
+            nb_setval(Var, Stored)
+        ),
+        Value = Stored
+    ;   nb_getval(Var, Value)
+    ).
 
 %%% Eval: %%%
 eval(C, Out) :- translate_expr(C, Goals, Out),


### PR DESCRIPTION
## Summary

Fix `get-state` so requesting an undefined state initializes it with an empty value instead of raising an error.

## Problem

Previously, calling `get-state` on a state that had not been created with `new-state` caused an error because the implementation directly used `nb_getval/2`. This made expressions like:

```metta
!(test (get-state fresh-state) ())
```
fail when fresh-state did not already exist.

## Solution
- Updated get-state to:
- Check whether the state name is an atom.
- Return the existing stored value when the state already exists.
- Create the state with an empty value () when it does not exist yet.
- Preserve the previous behavior for non-atom cases.
- This makes get-state behave more safely and intuitively for newly referenced states.