### PR TITLE
Make import! idempotent to avoid duplicate module loads

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -279,6 +279,8 @@ retractPredicate(_, false).
 ensure_metta_ext(Path, Path) :- file_name_extension(_, metta, Path), !.
 ensure_metta_ext(Path, PathWithExt) :- file_name_extension(Path, metta, PathWithExt).
 
+:- dynamic imported_metta_file/2.
+
 'import!'(Space, File, true) :- catch(importer_helper(Space, File), _, fail).
 importer_helper(Space, File) :- atom_string(File, SFile),
                                 working_dir(Base),
@@ -291,7 +293,13 @@ importer_helper(Space, File) :- atom_string(File, SFile),
                                    ; ( Path = SFile ; atomic_list_concat([Base, '/', SFile], Path) ),
                                      ensure_metta_ext(Path, PathWithExt),
                                      exists_file(PathWithExt), !,
-                                     load_metta_file(PathWithExt, _, Space) ).
+                                     absolute_file_name(PathWithExt, CanonPath),
+                                     % import! is idempotent: loading the same file into the same
+                                     % space twice would duplicate every rule (compile -> 2^depth blowup).
+                                     ( imported_metta_file(Space, CanonPath)
+                                       -> true
+                                        ; assertz(imported_metta_file(Space, CanonPath)),
+                                          load_metta_file(PathWithExt, _, Space) ) ).
 
 :- dynamic translator_rule/1.
 'add-translator-rule!'(HV, true) :- ( translator_rule(HV)


### PR DESCRIPTION
'import!'/3 reloads a file into a space on every call, with no check for whether that (space, file) pair was already loaded. When more than one file in the import graph imports the same shared file, that file gets loaded once per path into the same space, and each load re-asserts every clause in it again.

The duplication compounds with import depth, so a project with a few levels of shared imports ends up with an exponentially larger, mostly-duplicate clause set for the same source. Anything that walks or matches over that set pays for it, and mm2compile's case dispatch can turn a compileadd call on a single tiny, lambda-free, one-atom statement into a multi-second hang or a stack overflow, purely from how many times the shared files got pulled in.

The fix tracks which (space, canonical-path) pairs have already been imported and skips the reload on a repeat import of the same file into the same space.

I hit this while running https://github.com/MesTTo/PeTTaChainer, a PLN reasoner built on top of this runtime, whose petta_chainer.metta import graph pulls several chainer/context modules through more than one path. I reproduced it against a clean checkout of this repo with no other changes, plus a freshly built mork_ffi/MORK/PathMap stack: constructing a MeTTa reasoner and calling compileadd/add_atom on `(: a (A) (STV 1.0 1.0))` didn't return within 60 seconds. Applying only this patch on the same clean checkout, nothing else changed, brought that same call under 1ms. PeTTaChainer's own test suite (tests/test_pettachainer.py, tests/test_pln_validator.py, etc.) also passes against the patched checkout.

Tested on Linux (Ubuntu 26.04 LTS, x86_64), SWI-Prolog 9.3.33 with janus-swi. Haven't checked macOS or Windows.
