### PR TITLE
fix: make non-editable pip install of the petta package work (#190)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 python/__pycache__
 python/HE/__pycache__
 python/tests/__pycache__
+python/petta/__pycache__
+
+# Python build artifacts
+build/
+dist/
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 recursive-include src *
+recursive-include lib *
+include python/helper.pl

--- a/python/petta/__init__.py
+++ b/python/petta/__init__.py
@@ -6,6 +6,25 @@ CONSULTED = False
 CONSULT_LOCK = threading.Lock()
 janus = None
 
+
+def _resolve_petta_path():
+    """Locate the PeTTa runtime tree (src/, lib/, python/helper.pl).
+
+    Prefers PETTA_PATH, then the runtime bundled in the installed package,
+    then the source-tree root (editable installs and checkouts).
+    """
+    env_path = os.environ.get("PETTA_PATH")
+    if env_path:
+        return os.path.abspath(env_path)
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    bundled = os.path.join(here, "_runtime")
+    if os.path.exists(os.path.join(bundled, "src", "main.pl")):
+        return bundled
+
+    return os.path.abspath(os.path.join(here, os.pardir, os.pardir))
+
+
 class PeTTa:
     def __init__(self, verbose=False, petta_path=None):
         global CONSULTED, janus
@@ -14,7 +33,7 @@ class PeTTa:
             with CONSULT_LOCK:
                 if not CONSULTED:
                     if petta_path is None:
-                        petta_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+                        petta_path = _resolve_petta_path()
                     morklib_file = os.path.join(petta_path, "mork_ffi", "target", "release", "libmork_ffi.so")
                     if os.path.exists(morklib_file):
                         orig_dir = os.getcwd()
@@ -26,6 +45,13 @@ class PeTTa:
                         janus = importlib.import_module("janus_swi")
                     main_file = os.path.join(petta_path, "src", "main.pl")
                     helper_file = os.path.join(petta_path, "python", "helper.pl")
+                    if not os.path.exists(main_file):
+                        raise FileNotFoundError(
+                            f"PeTTa runtime not found under {petta_path!r} "
+                            f"(expected {main_file!r}). Set the PETTA_PATH "
+                            "environment variable or pass petta_path to point at "
+                            "a PeTTa checkout."
+                        )
                     janus.consult(main_file)
                     janus.consult(helper_file)
                     CONSULTED = True

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,42 @@
-from setuptools import setup, find_packages
+import os
+import shutil
+
+from setuptools import setup
+from setuptools.command.build_py import build_py
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+# Runtime resources living outside the package that must ship inside the wheel,
+# mapped to their destination under petta/_runtime/ (preserving the src/ and
+# lib/ sibling layout that metta.pl relies on for library_path).
+RUNTIME_RESOURCES = {
+    "src": "src",
+    "lib": "lib",
+    os.path.join("python", "helper.pl"): os.path.join("python", "helper.pl"),
+}
+
+
+class build_py_with_runtime(build_py):
+    def run(self):
+        super().run()
+        runtime_root = os.path.join(self.build_lib, "petta", "_runtime")
+        for src_rel, dst_rel in RUNTIME_RESOURCES.items():
+            src = os.path.join(HERE, src_rel)
+            dst = os.path.join(runtime_root, dst_rel)
+            if os.path.isdir(src):
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+            else:
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+                shutil.copy2(src, dst)
+
 
 setup(
     name="petta",
     version="0.1.0",
-    packages=find_packages(where="python"),
+    packages=["petta"],
     package_dir={"": "python"},
     include_package_data=True,
+    cmdclass={"build_py": build_py_with_runtime},
     install_requires=[
         'janus-swi',
     ],

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,5 @@ setup(
         "License :: OSI Approved :: MIT License",  # Adjust based on LICENSE
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
## Description

Fixes #190.
`pip install .` produced a wheel with only `tests/` and dist-info, so `import petta` failed with `ModuleNotFoundError`. `petta.py` also resolved its Prolog runtime relative to the source tree, which is absent in a non-editable install.

## Updates
1. Turned `python/petta.py` into the `python/petta` package so the module is discovered and can carry bundled resources.
2. Ship the runtime (`src/`, `lib/`, `python/helper.pl`) inside the wheel via a `build_py` step that copies them into `petta/_runtime/`, preserving the `src/`–`lib/` sibling layout `metta.pl` relies on (`library_path = src/../lib`).
3. Resolve the runtime via `PETTA_PATH`, then the bundled `_runtime/`, then the source-tree root, with a clear error if none is found.
4. Extended `MANIFEST.in` for sdist builds and stopped leaking `tests` as a top-level package.

## Validation
- Non-editable `pip install .`, `PETTA_PATH` override, and `pip install -e .` all run MeTTa end-to-end.
- Existing `python/tests/` suite: 3/3 pass.