### PR TITLE
fix: allow py-call method calls on strings and numbers (#188)

### DIFF
--- a/examples/python.metta
+++ b/examples/python.metta
@@ -10,3 +10,7 @@
               ($temp (set-attribute $obj foo (math.pi))))
              (get-attribute $obj foo))
        3.141592653589793)
+
+;Verify py-call on methods of strings and numbers (see #188)
+!(test (py-call (.upper "abc")) ABC)
+!(test (py-call (.__add__ 5 3)) 8)

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -224,10 +224,14 @@ assert(Goal, true) :- ( call(Goal) -> true
                                         ( sub_atom(A, 0, 1, _, '.')         % ".method"
                                           -> sub_atom(A, 1, _, 0, Fun),
                                              Args = [Obj|Rest],
-                                             ( Rest == []
-                                               -> compound_name_arguments(Meth, Fun, [])
-                                                ; Meth =.. [Fun|Rest] ),
-                                             py_call(Obj:Meth, Result, Opts)
+                                             ( py_is_object(Obj)            % on a Python object reference
+                                               -> ( Rest == []
+                                                    -> compound_name_arguments(Meth, Fun, [])
+                                                     ; Meth =.. [Fun|Rest] ),
+                                                  py_call(Obj:Meth, Result, Opts)
+                                                ; py_call(builtins:type(Obj), Ty), % on a converted value (str, int, ...)
+                                                  Call =.. [Fun, Obj|Rest],
+                                                  py_call(Ty:Call, Result, Opts) )
                                            ; atomic_list_concat([M,F], '.', A) % "mod.fun"
                                              -> ( Args == []
                                                   -> compound_name_arguments(Call0, F, [])

--- a/test.sh
+++ b/test.sh
@@ -3,12 +3,14 @@
 run_test() {
     f="$1"
     echo "Running $f"
-    output=$(sh run.sh "$f" | grep "is " | grep " should ")
+    output=$(sh run.sh "$f")
+    error=$?
+    output=$(echo "$output"  | grep "is " | grep " should ")
     echo "$output" | grep -q "❌"
     fail=$?
     echo "$output" | grep -q "✅"
     pass=$?
-    if [ $fail -eq 0 ] || [ $pass -ne 0 ]; then
+    if [ $error -ne 0 ] || [ $fail -eq 0 ] || [ $pass -ne 0 ]; then
         echo "FAILURE in $f:"
         echo "$output"
         return 1


### PR DESCRIPTION
Fixes #188.

Calling a method on a string or number via `py-call` raised `ModuleNotFoundError: No module named ...`. For example:

```metta
!(let $s (py-str ("b")) (py-call (.join $s ("a" "c"))))
; before: ERROR ... Python 'ModuleNotFoundError': No module named 'b'
; after:  abc
```

## Cause

The `.method` branch of `py-call` runs `py_call(Obj:Meth)`, and janus reads the left-hand side of `:` as a **module name**. Real object references work because janus keeps them as opaque handles, but converted values (`str`, `int`, …) are plain Prolog terms, so janus tries to import them as modules — hence `No module named 'b'`.

## Fix

Branch on the receiver in the `.method` case (`src/metta.pl`):

- `py_is_object(Obj)` → keep `py_call(Obj:Meth)` (real object references — **unchanged**).
- otherwise → dispatch through the value's type: `py_call(type(Obj):Fun(Obj, Args...))`.

## Before / After

| Call | Before | After |
| --- | --- | --- |
| `(py-call (.upper "abc"))` | `ModuleNotFoundError` | `ABC` |
| `(py-call (.join "-" ("a" "b" "c")))` | `ModuleNotFoundError` | `a-b-c` |
| `(py-call (.replace "abc" "a" "x"))` | `ModuleNotFoundError` | `xbc` |
| `(py-call (.split "a,b,c" ","))` | `ModuleNotFoundError` | `(a b c)` |
| `(py-call (.__add__ 5 3))` | `ModuleNotFoundError` | `8` |

## Validation

- The issue's original example now returns `abc`.
- Existing paths are untouched: object methods (`.foo`, `.bar $a 3 4`), `mod.fun` (`math.sqrt`), and bare `fun` (`str`) all still work.
- `sh test.sh`: all 144 example tests pass. Python `pytest`: 3/3 pass.
