### PR TITLE
feat: add date & time library

### DIFF
--- a/examples/test_datetime.metta
+++ b/examples/test_datetime.metta
@@ -14,8 +14,15 @@
 !(let* (($ts 1766188800)
         ($dow (day-of-week $ts)))
     ($dow))
+!(test (day-of-week 1766188800) Saturday)
 
 !(let* (($ts1 1735689600)
         ($ts2 1736294400)
         ($diff (- $ts2 $ts1)))
     ($diff))
+!(test (- 1736294400 1735689600) 604800)
+
+!(let* (($ts 1735725045)
+        ($time-only (format-date $ts "%H:%M:%S")))
+    ($time-only))
+!(test (format-date 1735689600 "%B") January)

--- a/examples/test_datetime.metta
+++ b/examples/test_datetime.metta
@@ -1,0 +1,21 @@
+!(import! &self ../lib/lib_datetime)
+
+!(let $now-ts (now) ($now-ts))
+
+!(let* (($now-ts (now))
+        ($formatted (format-date $now-ts "%Y-%m-%d %H:%M:%S")))
+    ($formatted))
+
+!(let* (($ts (now))
+        ($plus-3600 (+ $ts 3600))
+        ($formatted (format-date $plus-3600 "%Y-%m-%d %H:%M:%S")))
+    ($formatted))
+
+!(let* (($ts 1766188800)
+        ($dow (day-of-week $ts)))
+    ($dow))
+
+!(let* (($ts1 1735689600)
+        ($ts2 1736294400)
+        ($diff (- $ts2 $ts1)))
+    ($diff))

--- a/lib/lib_datetime.metta
+++ b/lib/lib_datetime.metta
@@ -1,0 +1,8 @@
+!(import! &self (library lib_import))
+!(import_prolog_functions_from_file (library lib_datetime.pl) (now format_date day_of_week))
+
+(= (format-date $timestamp $format)
+   (format_date $timestamp $format))
+
+(= (day-of-week $timestamp)
+   (day_of_week $timestamp))

--- a/lib/lib_datetime.pl
+++ b/lib/lib_datetime.pl
@@ -1,0 +1,10 @@
+now(TimeStamp) :-
+    get_time(TimeStamp).
+
+format_date(TimeStamp, Format, Formatted) :-
+    stamp_date_time(TimeStamp, DateTime, 'UTC'),
+    format_time(atom(Formatted), Format, DateTime).
+
+day_of_week(TimeStamp, DayName) :-
+    stamp_date_time(TimeStamp, DateTime, 'UTC'),
+    format_time(atom(DayName), '%A', DateTime).


### PR DESCRIPTION
Adds simple date & time helpers:
- `now` - current Unix timestamp
- `format-date` - format timestamps with strftime patterns
- `day-of-week` - get weekday name for a timestamp

Test file added in `examples/test_datetime.metta`.