### PR TITLE
fix: make the remaining atom operations safe on non-list inputs

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -82,7 +82,9 @@ exp(Arg,R) :- R is exp(Arg).
 'atan-math'(A, Out) :- Out is atan(A).
 'isnan-math'(A, Out) :- ( A =:= A -> Out = false ; Out = true ).
 'isinf-math'(A, Out) :- ( A =:= 1.0Inf ; A =:= -1.0Inf -> Out = true ; Out = false ).
+'min-atom'(List, Out) :- non_list(List), !, Out = [].
 'min-atom'(List, Out) :- min_list(List, Out).
+'max-atom'(List, Out) :- non_list(List), !, Out = [].
 'max-atom'(List, Out) :- max_list(List, Out).
 
 %%% Random Generators: %%%
@@ -111,6 +113,7 @@ empty(_) :- fail.
 'first-from-pair'([A, _], A).
 first([A, _], A).
 'second-from-pair'([_, A], A).
+'unique-atom'(A, B) :- non_list(A), !, B = [].
 'unique-atom'(A, B) :- list_to_set(A, B).
 
 %%% Alpha-equivalence unique atom %%%
@@ -135,7 +138,13 @@ alpha_list_to_set_assoc([H|T], SeenIn, R) :-
         alpha_list_to_set_assoc(T, SeenOut, RT)
     ).
 
+%A term that can never become a list, no matter how it gets instantiated:
+non_list(X) :- atomic(X), X \== [].
+non_list(X) :- compound(X), X \= [_|_].
+
+'sort-atom'(List, Sorted) :- non_list(List), !, Sorted = [].
 'sort-atom'(List, Sorted) :- msort(List, Sorted).
+'size-atom'(List, Size) :- non_list(List), !, Size = [].
 'size-atom'(List, Size) :- length(List, Size).
 'car-atom'([H|_], H) :- !.
 'car-atom'(_, []).
@@ -162,6 +171,7 @@ member_alpha(X, [_|T]) :- member_alpha(X, T).
                                                             ; Out = [H|Rest],
                                                               'subtraction-atom'(T, B, Rest) ).
 'union-atom'(A, B, Out) :- append(A, B, Out).
+'intersection-atom'(A, B, Out) :- ( non_list(A) ; non_list(B) ), !, Out = [].
 'intersection-atom'(A, B, Out) :- intersection(A, B, Out).
 
 %%% Type system: %%%


### PR DESCRIPTION
## Description

Follow-up to #183, which fixed `car-atom` and `cdr-atom` for #182.
`size-atom`, `sort-atom`, `unique-atom`, `min-atom`, `max-atom` and `intersection-atom` pass their argument straight to `length/2`, `msort/2`, `list_to_set/2`, `min_list/2`, `max_list/2` and `intersection/3`, so a non-list argument aborts the program:

```metta
!(size-atom 5)
; ERROR: length/2: Type error: `list' expected, found `5' (an integer)
```

## Cause

Same problem #182 reported for `car-atom`. As noted in #183, `and` is deliberately relational and evaluates both operands, so a metatype guard does not prevent the call:

```metta
(= (is-pair $x)
   (and (== (get-metatype $x) Expression)
        (== 2 (size-atom $x))))

!(is-pair A)   ; crashes: length/2: Type error: `list' expected, found `A'
```

The hazard applies to every partial builtin, not just the two that were reported.

## Change

Return `()` on inputs that cannot be lists, following the convention `car-atom` and `cdr-atom` already use:

```prolog
non_list(X) :- atomic(X), X \== [].
non_list(X) :- compound(X), X \= [_|_].
```

The guard rejects only terms that can never become a list. Unbound variables and partial lists still reach the underlying predicate, so relational uses keep working: `examples/logicprogset.metta` calls `(size-atom $M)` with `$M` unbound so `length/2` closes the open list produced by `member`. An `is_list/1` guard would silently break it.

`()` rather than `0` for `size-atom`, since `0` would make `(== 0 (size-atom 5))` true.

## Validation

In the CI image (`ghcr.io/patham9/petta-ci:latest`, SWI-Prolog 9.3.35): `sh test.sh` exits 0 with 144 example files OK and 501 assertions passing, identical to the `main` baseline. Non-list inputs return `()`; valid inputs are unchanged. `examples/logicprogset.metta` still passes, and `car-atom`/`cdr-atom` are untouched.