### PR TITLE
fix: correctness bugs in isinf-math, intersection-atom, index-atom and alpha-unique-atom

### DIFF
--- a/examples/atomops.metta
+++ b/examples/atomops.metta
@@ -19,3 +19,21 @@
 !(test (first-from-pair (A B)) A)
 
 !(test (second-from-pair (A B)) B)
+
+!(test (index-atom (1 2 3) 5) ())
+
+!(test (index-atom (1 2 3) a) ())
+
+!(test (size-atom 5) ())
+
+!(test (sort-atom 5) ())
+
+!(test (unique-atom 5) ())
+
+!(test (alpha-unique-atom 5) ())
+
+!(test (min-atom 5) ())
+
+!(test (max-atom 5) ())
+
+!(test (intersection-atom 5 (a)) ())

--- a/examples/he_math.metta
+++ b/examples/he_math.metta
@@ -17,3 +17,5 @@
 !(test (isinf-math 0.0) False)
 !(test (min-atom (2 6 7 4 9 3)) 2)
 !(test (max-atom (2 6 7 4 9 3)) 9)
+!(test (isinf-math inf) True)
+!(test (isnan-math nan) True)

--- a/examples/math.metta
+++ b/examples/math.metta
@@ -17,3 +17,5 @@
 !(test (isinf-math 0.0) False)
 !(test (min-atom (2 6 7 4 9 3)) 2)
 !(test (max-atom (2 6 7 4 9 3)) 9)
+!(test (isinf-math inf) True)
+!(test (isnan-math nan) True)

--- a/examples/multiset_operations.metta
+++ b/examples/multiset_operations.metta
@@ -2,3 +2,7 @@
 !(test (union-atom (a b b c) (b c c d)) (a b b c b c c d))
 !(test (intersection-atom (a b c c) (b c c c d)) (b c c))
 !(test (subtraction-atom (a b b c) (b c c d)) (a b))
+!(test (intersection-atom (a b c c) (b c d)) (b c))
+!(test (intersection-atom (a a a) (a)) (a))
+!(test (subtraction-atom (a a a) (a)) (a a))
+!(test (intersection-atom (a b) ()) ())

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -81,8 +81,10 @@ exp(Arg,R) :- R is exp(Arg).
 'acos-math'(A, Out) :- Out is acos(A).
 'atan-math'(A, Out) :- Out is atan(A).
 'isnan-math'(A, Out) :- ( A =:= A -> Out = false ; Out = true ).
-'isinf-math'(A, Out) :- ( A =:= 1.0Inf ; A =:= -1.0Inf -> Out = true ; Out = false ).
+'isinf-math'(A, Out) :- ( ( A =:= 1.0Inf ; A =:= -1.0Inf ) -> Out = true ; Out = false ).
+'min-atom'(List, Out) :- non_list(List), !, Out = [].
 'min-atom'(List, Out) :- min_list(List, Out).
+'max-atom'(List, Out) :- non_list(List), !, Out = [].
 'max-atom'(List, Out) :- max_list(List, Out).
 
 %%% Random Generators: %%%
@@ -111,12 +113,12 @@ empty(_) :- fail.
 'first-from-pair'([A, _], A).
 first([A, _], A).
 'second-from-pair'([_, A], A).
+'unique-atom'(A, B) :- non_list(A), !, B = [].
 'unique-atom'(A, B) :- list_to_set(A, B).
 
 %%% Alpha-equivalence unique atom %%%
-'alpha-unique-atom'(A, B) :-
-    must_be(list, A),
-    alpha_list_to_set(A, B).
+'alpha-unique-atom'(A, B) :- non_list(A), !, B = [].
+'alpha-unique-atom'(A, B) :- alpha_list_to_set(A, B).
 
 alpha_list_to_set(List, Set) :-
     empty_assoc(Seen0),
@@ -135,7 +137,13 @@ alpha_list_to_set_assoc([H|T], SeenIn, R) :-
         alpha_list_to_set_assoc(T, SeenOut, RT)
     ).
 
+%A term that can never become a list, no matter how it gets instantiated:
+non_list(X) :- atomic(X), X \== [].
+non_list(X) :- compound(X), X \= [_|_].
+
+'sort-atom'(List, Sorted) :- non_list(List), !, Sorted = [].
 'sort-atom'(List, Sorted) :- msort(List, Sorted).
+'size-atom'(List, Size) :- non_list(List), !, Size = [].
 'size-atom'(List, Size) :- length(List, Size).
 'car-atom'([H|_], H) :- !.
 'car-atom'(_, []).
@@ -143,6 +151,7 @@ alpha_list_to_set_assoc([H|T], SeenIn, R) :-
 'cdr-atom'(_, []).
 decons([H|T], [H|[T]]).
 cons(H, T, [H|T]).
+'index-atom'(_, Index, _) :- nonvar(Index), \+ integer(Index), !, fail.
 'index-atom'(List, Index, Elem) :- nth0(Index, List, Elem).
 member(X, L, true) :- member(X, L).
 'is-member'(X, List, true) :- member(X, List).
@@ -162,7 +171,11 @@ member_alpha(X, [_|T]) :- member_alpha(X, T).
                                                             ; Out = [H|Rest],
                                                               'subtraction-atom'(T, B, Rest) ).
 'union-atom'(A, B, Out) :- append(A, B, Out).
-'intersection-atom'(A, B, Out) :- intersection(A, B, Out).
+'intersection-atom'(A, B, Out) :- ( non_list(A) ; non_list(B) ), !, Out = [].
+'intersection-atom'([], _, []).
+'intersection-atom'([H|T], B, Out) :- ( select(H, B, BRest) -> Out = [H|Rest],
+                                                              'intersection-atom'(T, BRest, Rest)
+                                                            ; 'intersection-atom'(T, B, Out) ).
 
 %%% Type system: %%%
 get_function_type([F|Args], T) :- nonvar(F), match('&self', [':',F,[->|Ts]], _, _),


### PR DESCRIPTION
## Description

Fixes four correctness bugs in the builtin operations, each reproducible in a couple of lines of MeTTa. Three of them abort or return garbage on input that MeTTa code can legitimately produce.

Replaces #197, whose changes are included here: fixing `intersection-atom`'s semantics touches the same predicate that PR guarded.

## Updates

**1. `isinf-math` never returned `true`.**

```metta
!(collapse (isinf-math inf))
; before: ($_100456 false)
; after:  (true)
```

`->` binds tighter than `;`, so the body parsed as `A =:= 1.0Inf ; ((A =:= -1.0Inf -> Out = true) ; Out = false)`. For `+inf` the first disjunct succeeds and `Out` is never bound, leaving an unbound variable as a result and no `true` among the solutions. Since `lib_builtin_types.metta` declares `(: isinf-math (-> Number Bool))`, that also breaks the declared type.

`inf` is the only infinity reachable from MeTTa — `pow-math 10.0 400` raises `float_overflow`, `/ 1 0` raises `zero_divisor`, and `-inf` does not parse as a number — so the function could never report one. It survived because `math.metta` and `he_math.metta` only tested the `False` branch.

**2. `intersection-atom` was not a multiset intersection.**

```metta
!(intersection-atom (a a a) (a))
; before: (a a a)
; after:  (a)
```

It called `intersection/3`, which keeps every element of the first list that occurs anywhere in the second, so the result could be larger than an operand. Its siblings under the same `%Multisets:` header are correct: `subtraction-atom` tracks multiplicity and `union-atom` concatenates. It now mirrors `subtraction-atom`, consuming a match from the second list so the result carries the minimum multiplicity of the two.

The existing test in `multiset_operations.metta` passed only because its duplicated element occurred more often in the second list than in the first.

**3. `index-atom` aborted on a non-integer index.**

```metta
!(index-atom (1 2 3) a)
; before: nth0/3 type error, `integer' expected
; after:  Empty
```

An out-of-range index already yields `Empty`; a non-integer one now does the same instead of aborting. An unbound index still enumerates the list.

**4. `alpha-unique-atom` aborted on non-list input.**

```metta
!(alpha-unique-atom 5)
; before: must_be/2 type error, `list' expected
; after:  ()
```

`unique-atom` and the other atom operations return `()` here.

## Validation

Regression tests cover the branches these bugs lived in: the `true` branch of `isinf-math` and `isnan-math`, multiset intersection where the first list has the higher multiplicity, and non-list input to the atom operations.

- Full example suite in the CI image (SWI-Prolog 9.3.35): 144 files, 518 assertions, 0 failures.
- Reverting only `src/metta.pl` and keeping the tests makes each one fail — `is (b c c), should (b c)`, `is ($_146418 false), should true`, and a crash in `atomops.metta` — so none of them pass vacuously.
