### PR TITLE
py-call: normalize janus booleans to language booleans

### DIFF
--- a/src/metta.pl
+++ b/src/metta.pl
@@ -218,6 +218,11 @@ assert(Goal, true) :- ( call(Goal) -> true
 'format-time'(Format, TimeString) :- get_time(Time), format_time(atom(TimeString), Format, Time).
 
 %%% Python bindings: %%%
+% janus converts Python booleans to @(true)/@(false); normalize them to the
+% language booleans so py-call results compose with if, and, or, ==.
+py_bool_norm('@'(true), true) :- !.
+py_bool_norm('@'(false), false) :- !.
+py_bool_norm(R, R).
 'py-call'(SpecList, Result) :- 'py-call'(SpecList, Result, []).
 'py-call'([Spec|Args], Result, Opts) :- ( string(Spec) -> atom_string(A, Spec) ; A = Spec ),
                                         must_be(atom, A),
@@ -228,19 +233,19 @@ assert(Goal, true) :- ( call(Goal) -> true
                                                -> ( Rest == []
                                                     -> compound_name_arguments(Meth, Fun, [])
                                                      ; Meth =.. [Fun|Rest] ),
-                                                  py_call(Obj:Meth, Result, Opts)
+                                                  py_call(Obj:Meth, R0, Opts), py_bool_norm(R0, Result)
                                                 ; py_call(builtins:type(Obj), Ty), % on a converted value (str, int, ...)
                                                   Call =.. [Fun, Obj|Rest],
-                                                  py_call(Ty:Call, Result, Opts) )
+                                                  py_call(Ty:Call, R0, Opts), py_bool_norm(R0, Result) )
                                            ; atomic_list_concat([M,F], '.', A) % "mod.fun"
                                              -> ( Args == []
                                                   -> compound_name_arguments(Call0, F, [])
                                                    ; Call0 =.. [F|Args] ),
-                                                py_call(M:Call0, Result, Opts)
+                                                py_call(M:Call0, R0, Opts), py_bool_norm(R0, Result)
                                               ; ( Args == []                      % bare "fun"
                                                   -> compound_name_arguments(Call0, A, [])
                                                    ; Call0 =.. [A|Args] ),
-                                                py_call(builtins:Call0, Result, Opts) ).
+                                                py_call(builtins:Call0, R0, Opts), py_bool_norm(R0, Result) ).
 
 %%% States: %%%
 'bind!'(A, ['new-state', B], C) :- 'change-state!'(A, B, C).

--- a/tests/regression/repro5_pybool_if_condition.metta
+++ b/tests/regression/repro5_pybool_if_condition.metta
@@ -1,0 +1,2 @@
+!(if (py-call (builtins.bool 1)) py-true-taken py-true-not-taken)
+!(if (py-call (builtins.bool 0)) py-false-taken py-false-not-taken)


### PR DESCRIPTION
## The silent trap

janus marshals Python `True`/`False` into Prolog as `@(true)`/`@(false)`. PeTTa's `if` compiles to `(Cv == true -> …)`, so any `(if (py-call …) a b)` over a Python boolean silently takes the **else** branch — no error, wrong branch. We hit this live: a Python-side flag check that never fired, twice, before we found it.

Zero-dependency repro (included as `tests/regression/repro5_pybool_if_condition.metta`):

```
!(if (py-call (builtins.bool 1)) py-true-taken py-true-not-taken)
!(if (py-call (builtins.bool 0)) py-false-taken py-false-not-taken)
```

On current main this prints `py-true-not-taken` / `py-false-not-taken`.

## The fix (one option — your call)

Normalize `@(true)`/`@(false)` to `true`/`false` at the `'py-call'` result boundary (all four call sites), so Python booleans compose with `if`/`and`/`or`/`==` like language booleans. With the patch the repro prints `py-true-taken` / `py-false-not-taken`, and `tests/regression/test_specializer_regressions.sh` still passes.

The alternative we considered: leave marshalling as-is and document a 1/0 integer convention for Python→MeTTa truth (we use that in our agent code today). Normalizing at the boundary seemed the least-surprise option for downstream users, but if you prefer `@(true)` stay observable, happy to rework this into docs + repro only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)