### PR TITLE
fix: swrite drops backslashes in string literals, breaking the swrite/sread round-trip

### DIFF
--- a/examples/parse.metta
+++ b/examples/parse.metta
@@ -3,3 +3,6 @@
 !(test (parse "(R A (S B C))") (R A (S B C)))
 !(test (parse "(* 2 21)") (quote (* 2 21)))
 !(test (parse "\"42\"") "42")
+!(test (parse (repr "C:\\Users\\bob")) "C:\\Users\\bob")
+!(test (parse (repr "say \"hi\"")) "say \"hi\"")
+!(test (parse (repr "a\\nb")) "a\\nb")

--- a/src/parser.pl
+++ b/src/parser.pl
@@ -14,6 +14,7 @@ swrite_exp(Term)  --> { Term =.. [F|Args] }, "(", atom(F), ( { Args == [] } -> [
 seq([X])    --> swrite_exp(X).
 seq([X|Xs]) --> swrite_exp(X), " ", seq(Xs).
 escape_quotes([], []).
+escape_quotes([0'\\|T], [0'\\,0'\\|R]) :- !, escape_quotes(T, R).
 escape_quotes([0'"|T], [0'\\,0'"|R]) :- !, escape_quotes(T, R).
 escape_quotes([H|T], [H|R]) :- escape_quotes(T, R).
 


### PR DESCRIPTION
## Description

`swrite` is documented as the inverse of the reader ("Generate a MeTTa S-expression string from the Prolog list (inverse parsing)"), so `parse (repr X)` is expected to return `X`. This does not hold for any string containing a backslash.

`swrite` serializes strings through `escape_quotes`, which escaped `"` but copied every other character verbatim, including the backslash. The reader (`string_chars`) treats a backslash as an escape introducer (`\n`, `\t`, `\r`, `\"`, `\\`), so a lone backslash emitted by `swrite` is consumed as an escape when the value is read back. The result is either silent data loss or corruption into a control character:

```
(repr "C:\Users\bob")  ->  parse  ->  "C:Usersbob"     ; backslashes dropped
(repr "a\nb")          ->  parse  ->  "a<newline>b"     ; \n reinterpreted as a newline
```

## Updates

1. `escape_quotes` now escapes the backslash. A single `\ -> \\` clause, placed before the existing `"` clause, mirrors the reader's grammar so that every character the reader would interpret after a backslash is written back as `\\`. This restores `parse (repr X) == X`.

## Validation

Round-trip regression tests were added to `examples/parse.metta`:

```metta
!(test (parse (repr "C:\\Users\\bob")) "C:\\Users\\bob")
!(test (parse (repr "say \"hi\"")) "say \"hi\"")
!(test (parse (repr "a\\nb")) "a\\nb")
```

The two backslash cases fail on `main` and pass with the fix; the embedded-quote case passes throughout and guards the existing escape behaviour. Full example suite: 144 files, 504 assertions, 0 failures.
