### PR TITLE
Extract miscellaneous runtime improvements from import work

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ The following projects are cloned and built by build.sh:
 
 Please check out [Extension libraries](https://github.com/trueagi-io/PeTTa/wiki/Extension-libraries) for a set of extension libraries that can be invoked from MeTTa files directly from the git repository.
 
+Git imports retain the legacy URL-only, URL/build-command, and
+URL/build-command/base-directory forms. For a reproducible detached checkout,
+pass a fourth input in the order URL, build command, base directory, commit:
+
+```metta
+!(git-import! "https://example/repo.git" "" "./repos" "0123456789abcdef0123456789abcdef01234567")
+```
+
+Pinned imports accept only a full 40-character hexadecimal commit SHA;
+abbreviated SHAs, branches, and tags are rejected.
+
 ## Notebooks, Servers, Browser
 
 ### Jupyter Notebook Support

--- a/examples/add_atom_fun_space.metta
+++ b/examples/add_atom_fun_space.metta
@@ -1,0 +1,4 @@
+(= (space) my_space_name)
+
+!(add-atom (space) (my test atom))
+!(test (match (space) $a $a) (my test atom))

--- a/examples/lib_roman_pair_helpers.metta
+++ b/examples/lib_roman_pair_helpers.metta
@@ -1,0 +1,7 @@
+!(import! &self ../lib/lib_roman)
+
+(= (inc $x) (+ $x 1))
+
+!(test (first inc (1 9)) (2 9))
+!(test (second inc (1 9)) (1 10))
+!(test (flip (left right)) (right left))

--- a/lib/lib_import.pl
+++ b/lib/lib_import.pl
@@ -1,3 +1,7 @@
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module(library(random)).
+
 %Translate a MeTTa S-expression file (no code, no bangs) to prolog predicates to load:
 metta_file_to_prolog(Input, Space, Output) :- setup_call_cleanup( open(Input, read, In),
                                                                   setup_call_cleanup( open(Output, write, Out),
@@ -87,6 +91,163 @@ replace_all(P, R, S, O) :- split_string(S, P, "", Parts),
                                                                                  ; clone_repo(GitPath, LocalDir),
                                                                                    run_build_step(LocalDir, BuildCmd) ),
                                                    asserta(library_path(LocalDir)).
+
+% Reproducible import: URL, build command, base directory, full commit SHA.
+'git-import!'(GitPath, BuildCmd, BaseDir, CommitSHA, true) :-
+    validate_commit_sha(CommitSHA, Commit),
+    make_directory_path(BaseDir),
+    repo_name_from_git(GitPath, Name),
+    directory_file_path(BaseDir, Name, LocalDir),
+    atom_concat(LocalDir, '.lock', LockFile),
+    setup_call_cleanup(open(LockFile, append, Lock, [lock(write)]),
+                       pinned_import_locked(GitPath, BuildCmd, BaseDir, Name, LocalDir, Commit),
+                       close(Lock)),
+    asserta(library_path(LocalDir)).
+
+validate_commit_sha(CommitSHA, Commit) :-
+    atom_string(CommitSHA, CommitString),
+    string_length(CommitString, 40),
+    string_codes(CommitString, Codes),
+    maplist(hex_code, Codes), !,
+    string_lower(CommitString, Lower),
+    atom_string(Commit, Lower).
+validate_commit_sha(CommitSHA, _) :-
+    throw(error(domain_error(full_git_commit_sha, CommitSHA),
+                context('git-import!'/5,
+                        'commit SHA must be exactly 40 hexadecimal characters'))).
+
+hex_code(Code) :- between(0'0, 0'9, Code), !.
+hex_code(Code) :- between(0'a, 0'f, Code), !.
+hex_code(Code) :- between(0'A, 0'F, Code).
+
+pinned_import_locked(GitPath, BuildCmd, BaseDir, Name, LocalDir, Commit) :-
+    ( exists_directory(LocalDir)
+      -> pinned_existing_checkout(GitPath, BuildCmd, LocalDir, Commit)
+       ; exists_file(LocalDir)
+      -> throw(error(permission_error(create, git_checkout, LocalDir),
+                     context('git-import!'/5, 'target exists and is not a directory')))
+       ; pinned_fresh_checkout(GitPath, BuildCmd, BaseDir, Name, LocalDir, Commit) ).
+
+pinned_fresh_checkout(GitPath, BuildCmd, BaseDir, Name, LocalDir, Commit) :-
+    create_staging_directory(BaseDir, Name, StagingRoot),
+    directory_file_path(StagingRoot, Name, StagingDir),
+    setup_call_cleanup(
+        true,
+        ( checked_process('clone repository', path(git),
+                          [clone, '--no-checkout', GitPath, StagingDir], []),
+          resolve_requested_commit(StagingDir, Commit),
+          checkout_detached(StagingDir, Commit),
+          verify_head(StagingDir, Commit),
+          run_checked_build_step(StagingDir, BuildCmd),
+          rename_file(StagingDir, LocalDir) ),
+        delete_directory_and_contents(StagingRoot)).
+
+create_staging_directory(BaseDir, Name, StagingRoot) :-
+    between(1, 100, _),
+    random_between(100000000, 999999999, Suffix),
+    format(atom(TempName), '.~w.git-import-~d', [Name, Suffix]),
+    directory_file_path(BaseDir, TempName, Candidate),
+    catch(make_directory(Candidate), error(existence_error(_, _), _), fail), !,
+    StagingRoot = Candidate.
+create_staging_directory(_, Name, _) :-
+    throw(error(resource_error(temporary_directory), context('git-import!'/5, Name))).
+
+pinned_existing_checkout(GitPath, BuildCmd, LocalDir, Commit) :-
+    ensure_git_checkout(LocalDir),
+    ensure_expected_origin(LocalDir, GitPath),
+    git_output('resolve current HEAD', LocalDir, ['rev-parse', '--verify', 'HEAD^{commit}'], Head),
+    ( Head == Commit
+      -> true
+       ; ensure_clean_checkout(LocalDir),
+         resolve_requested_commit(LocalDir, Commit),
+         checkout_detached(LocalDir, Commit),
+         verify_head(LocalDir, Commit),
+         run_checked_build_step(LocalDir, BuildCmd) ).
+
+ensure_git_checkout(LocalDir) :-
+    catch(git_output('validate Git checkout', LocalDir,
+                     ['rev-parse', '--is-inside-work-tree'], IsGit), _, fail),
+    IsGit == true, !.
+ensure_git_checkout(LocalDir) :-
+    throw(error(domain_error(git_checkout, LocalDir),
+                context('git-import!'/5, 'existing target is not a Git checkout'))).
+
+ensure_expected_origin(LocalDir, GitPath) :-
+    git_output('read origin URL', LocalDir, [remote, 'get-url', origin], Actual),
+    atom_string(GitPath, ExpectedString),
+    atom_string(Expected, ExpectedString),
+    ( Actual == Expected -> true
+    ; throw(error(domain_error(git_origin, Actual),
+                  context('git-import!'/5, expected(Expected)))) ).
+
+ensure_clean_checkout(LocalDir) :-
+    git_output('check checkout cleanliness', LocalDir,
+               [status, '--porcelain', '--untracked-files=all'], Status),
+    ( Status == '' -> true
+    ; throw(error(permission_error(modify, dirty_git_checkout, LocalDir),
+                  context('git-import!'/5, Status))) ).
+
+resolve_requested_commit(LocalDir, Commit) :-
+    checked_process('fetch requested commit', path(git),
+                    [fetch, '--no-tags', origin, Commit], [cwd(LocalDir)]),
+    atom_concat(Commit, '^{commit}', CommitObject),
+    checked_process('resolve requested commit object', path(git),
+                    ['cat-file', '-e', CommitObject], [cwd(LocalDir)]).
+
+checkout_detached(LocalDir, Commit) :-
+    checked_process('checkout requested commit', path(git),
+                    [checkout, '--detach', Commit], [cwd(LocalDir)]).
+
+verify_head(LocalDir, Commit) :-
+    git_output('verify checked out HEAD', LocalDir,
+               ['rev-parse', '--verify', 'HEAD^{commit}'], Head),
+    ( Head == Commit -> true
+    ; throw(error(consistency_error(git_head, Commit, Head),
+                  context('git-import!'/5, LocalDir))) ).
+
+git_output(Operation, LocalDir, Args, OutputAtom) :-
+    checked_process_output(Operation, path(git), Args, [cwd(LocalDir)], Output),
+    normalize_space(atom(OutputAtom), Output).
+
+run_checked_build_step(_, BuildCmd) :- (BuildCmd = '' ; BuildCmd = ""), !.
+run_checked_build_step(LocalDir, BuildCmd) :-
+    format("Running build: ~w in ~w~n", [BuildCmd, LocalDir]),
+    checked_process('build imported repository', path(sh), [BuildCmd], [cwd(LocalDir)]).
+
+checked_process(Operation, Executable, Args, Options) :-
+    checked_process_output(Operation, Executable, Args, Options, _).
+
+checked_process_output(Operation, Executable, Args, Options, Output) :-
+    tmp_file(git_import_stdout, OutFile),
+    tmp_file(git_import_stderr, ErrFile),
+    open(OutFile, write, Out),
+    open(ErrFile, write, Err),
+    setup_call_cleanup(
+        true,
+        ( setup_call_cleanup(
+              true,
+              run_logged_process(Operation, Executable, Args, Options, Out, Err, Status),
+              (close(Out), close(Err))),
+          read_process_log(OutFile, Stdout),
+          read_process_log(ErrFile, Stderr) ),
+        cleanup_process_logs(OutFile, ErrFile)),
+    string_concat(Stdout, Stderr, Output),
+    ( Status == exit(0) -> true
+    ; throw(error(process_error(Operation, Status, Output),
+                  context('git-import!'/5, Args))) ).
+
+read_process_log(File, Output) :-
+    setup_call_cleanup(open(File, read, In), read_string(In, _, Output), close(In)).
+
+cleanup_process_logs(OutFile, ErrFile) :-
+    ( exists_file(OutFile) -> delete_file(OutFile) ; true ),
+    ( exists_file(ErrFile) -> delete_file(ErrFile) ; true ).
+
+run_logged_process(Operation, Executable, Args, Options, Out, Err, Status) :-
+    append(Options, [stdout(stream(Out)), stderr(stream(Err)), process(PID)], ProcessOptions),
+    catch(process_create(Executable, Args, ProcessOptions), Error,
+          throw(error(process_error(Operation, Error), context('git-import!'/5, Args)))),
+    process_wait(PID, Status).
 
 %Extract "repo" from ".../repo.git" or "...:repo.git":
 repo_name_from_git(GitPath, Name) :- atom_string(GitPath, S),

--- a/lib/lib_roman.metta
+++ b/lib/lib_roman.metta
@@ -87,5 +87,12 @@
 (= (fst ($a $b)) $a)
 (= (snd ($a $b)) $b)
 
+(= (first $f ($a $b)) (($f $a) $b))
+(= (second $f ($a $b)) ($a ($f $b)))
+
+(= (cns ($a $b)) (cons $a $b))
+
+(= (flip ($a $b)) ($b $a))
+
 ;(= (prog1 (cons $x $xs)) $x)
 ;(= (progn (rcons $xs $x)) $x)

--- a/python/petta/__init__.py
+++ b/python/petta/__init__.py
@@ -5,6 +5,7 @@ import importlib
 CONSULTED = False
 CONSULT_LOCK = threading.Lock()
 janus = None
+DEFAULT_STACK_LIMIT = 8_000_000_000
 
 
 def _resolve_petta_path():
@@ -39,10 +40,12 @@ class PeTTa:
                         orig_dir = os.getcwd()
                         os.chdir(petta_path)
                         janus = importlib.import_module("janus_swi")
+                        janus.query_once(f"set_prolog_flag(stack_limit, {DEFAULT_STACK_LIMIT})")
                         os.chdir(orig_dir)
                         janus.query_once("set_prolog_flag(argv, ['mork'])")
                     else:
                         janus = importlib.import_module("janus_swi")
+                        janus.query_once(f"set_prolog_flag(stack_limit, {DEFAULT_STACK_LIMIT})")
                     main_file = os.path.join(petta_path, "src", "main.pl")
                     helper_file = os.path.join(petta_path, "python", "helper.pl")
                     if not os.path.exists(main_file):

--- a/python/petta/__init__.py
+++ b/python/petta/__init__.py
@@ -29,7 +29,7 @@ def _resolve_petta_path():
 class PeTTa:
     def __init__(self, verbose=False, petta_path=None):
         global CONSULTED, janus
-        self.verbose = "true" if verbose else "false"
+        self.verbose = bool(verbose)
         if not CONSULTED:
             with CONSULT_LOCK:
                 if not CONSULTED:

--- a/python/tests/test_petta.py
+++ b/python/tests/test_petta.py
@@ -1,4 +1,31 @@
 import uuid
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("verbose", "expected_binding"),
+    [(False, "false"), (True, "true")],
+)
+def test_run_helper_binds_verbose_atom(
+    monkeypatch, petta_module, verbose, expected_binding
+):
+    query_once = Mock(return_value={"Results": []})
+    monkeypatch.setattr(petta_module, "CONSULTED", True)
+    monkeypatch.setattr(petta_module, "janus", Mock(query_once=query_once))
+
+    petta_module.PeTTa(verbose=verbose).process_metta_string("!(+ 1 1)")
+
+    query_once.assert_called_once_with(
+        "run_metta_helper(Verbose, HelperName, Argument, Results)",
+        {
+            "Verbose": expected_binding,
+            "HelperName": "process_metta_string",
+            "Argument": "!(+ 1 1)",
+        },
+    )
+
 
 def test_load_metta_file_returns_list(petta_instance, dummy_metta_path):
     results = petta_instance.load_metta_file(str(dummy_metta_path))

--- a/src/main.pl
+++ b/src/main.pl
@@ -1,5 +1,17 @@
 :- ensure_loaded(metta).
 
+is_silent_flag(silent).
+is_silent_flag('--silent').
+is_silent_flag('-s').
+
+strip_silent_flags([], []).
+strip_silent_flags([Arg|Rest], Filtered) :-
+        is_silent_flag(Arg),
+        !,
+        strip_silent_flags(Rest, Filtered).
+strip_silent_flags([Arg|Rest], [Arg|Filtered]) :-
+        strip_silent_flags(Rest, Filtered).
+
 prologfunc(X,Y) :- Y is X+1.
 
 prolog_interop_example :- register_fun(prologfunc),
@@ -8,7 +20,8 @@ prolog_interop_example :- register_fun(prologfunc),
                           mettafunc(30, R),
                           format("mettafunc(30) = ~w~n", [R]).
 
-main :- current_prolog_flag(argv, Args),
+main :- current_prolog_flag(argv, RawArgs),
+        strip_silent_flags(RawArgs, Args),
         ( Args = [] -> prolog_interop_example
         ; Args = [mork] -> prolog_interop_example,
                            mork_test

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -260,9 +260,10 @@ translate_expr([H0|T0], Goals, Out) :-
                                            ( FreeVars == [] -> Out = F
                                                              ; Out = partial(F, FreeVars) )
         %--- Spaces ---:
-        ; ( HV == 'add-atom' ; HV == 'remove-atom' ), T = [_,_] -> append(T, [Out], RawArgs),
-                                                                   Goal =.. [HV|RawArgs],
-                                                                   append(GsH, [Goal], Goals)
+        ; ( HV == 'add-atom' ; HV == 'remove-atom' ), T = [Space,Atom] ->
+                                                                   translate_expr(Space, G1, S),
+                                                                   Goal =.. [HV,S,Atom,Out],
+                                                                   append([GsH,G1,[Goal]], Goals)
         ; HV == match, T = [Space, Pattern, Body] -> translate_expr(Space, G1, S),
                                                      translate_expr(Body, GsB, Out),
                                                      append(G1, [match(S, Pattern, Out, Out)], G2),

--- a/tests/test_git_import.sh
+++ b/tests/test_git_import.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+set -eu
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT HUP INT TERM
+
+remote="$fixture/fixture.git"
+source_repo="$fixture/source"
+base="$fixture/imports"
+mkdir -p "$source_repo" "$base"
+git -C "$source_repo" init -q
+git -C "$source_repo" config user.email test@example.invalid
+git -C "$source_repo" config user.name "PeTTa test"
+printf 'build artifact\n' > "$source_repo/payload.txt"
+printf '.build-count\n' > "$source_repo/.gitignore"
+printf '#!/bin/sh\ncount=0\ntest ! -f .build-count || count=$(cat .build-count)\necho $((count + 1)) > .build-count\n' > "$source_repo/build.sh"
+chmod +x "$source_repo/build.sh"
+git -C "$source_repo" add .
+git -C "$source_repo" commit -qm first
+first=$(git -C "$source_repo" rev-parse HEAD)
+printf 'tip\n' >> "$source_repo/payload.txt"
+git -C "$source_repo" commit -qam second
+second=$(git -C "$source_repo" rev-parse HEAD)
+git clone -q --bare "$source_repo" "$remote"
+
+run_import() {
+    url=$1
+    build=$2
+    import_base=$3
+    sha=$4
+    swipl -q -g "consult('$project_dir/lib/lib_import.pl'),'git-import!'('$url','$build','$import_base','$sha',true),halt"
+}
+
+# Fresh non-tip checkout and build.
+run_import "$remote" build.sh "$base" "$first"
+target="$base/fixture"
+test "$(git -C "$target" rev-parse HEAD)" = "$first"
+test "$(git -C "$target" symbolic-ref -q HEAD || true)" = ""
+test "$(cat "$target/.build-count")" = 1
+
+# The four-input form dispatches through the public MeTTa import layer.
+metta_base="$fixture/metta-imports"
+metta_program="$fixture/pinned-import.metta"
+printf '!(import! &self (library lib_import))\n!(git-import! "%s" "" "%s" "%s")\n' "$remote" "$metta_base" "$first" > "$metta_program"
+(cd "$project_dir" && sh run.sh "$metta_program")
+test "$(git -C "$metta_base/fixture" rev-parse HEAD)" = "$first"
+
+# Repeated invocation is idempotent and does not rerun the build.
+run_import "$remote" build.sh "$base" "$first"
+test "$(cat "$target/.build-count")" = 1
+
+# A clean transition fetches/checks out/builds the requested revision.
+run_import "$remote" build.sh "$base" "$second"
+test "$(git -C "$target" rev-parse HEAD)" = "$second"
+test "$(cat "$target/.build-count")" = 2
+
+# A transition refuses dirty state and preserves HEAD.
+printf 'dirty\n' >> "$target/payload.txt"
+if run_import "$remote" '' "$base" "$first" >"$fixture/dirty.log" 2>&1; then
+    echo "dirty transition unexpectedly succeeded" >&2
+    exit 1
+fi
+grep -q dirty_git_checkout "$fixture/dirty.log"
+test "$(git -C "$target" rev-parse HEAD)" = "$second"
+git -C "$target" checkout -q -- payload.txt
+
+# Invalid and unreachable revisions fail without registering or exposing a target.
+if run_import "$remote" '' "$fixture/invalid" deadbeef >"$fixture/invalid.log" 2>&1; then
+    echo "abbreviated SHA unexpectedly succeeded" >&2
+    exit 1
+fi
+grep -q "exactly 40 hexadecimal" "$fixture/invalid.log"
+unreachable=0000000000000000000000000000000000000000
+if run_import "$remote" '' "$fixture/unreachable" "$unreachable" >"$fixture/unreachable.log" 2>&1; then
+    echo "unreachable SHA unexpectedly succeeded" >&2
+    exit 1
+fi
+grep -q "fetch requested commit" "$fixture/unreachable.log"
+test ! -e "$fixture/unreachable/fixture"
+
+# Existing non-Git and wrong-origin targets are rejected.
+mkdir -p "$fixture/non-git/fixture"
+if run_import "$remote" '' "$fixture/non-git" "$first" >"$fixture/non-git.log" 2>&1; then
+    echo "non-Git target unexpectedly succeeded" >&2
+    exit 1
+fi
+grep -q "not a Git checkout" "$fixture/non-git.log"
+git clone -q "$remote" "$fixture/wrong/fixture"
+git -C "$fixture/wrong/fixture" remote set-url origin "$source_repo"
+if run_import "$remote" '' "$fixture/wrong" "$first" >"$fixture/wrong.log" 2>&1; then
+    echo "wrong origin unexpectedly succeeded" >&2
+    exit 1
+fi
+grep -q git_origin "$fixture/wrong.log"
+
+# A failed build leaves no partial target directory or library registration.
+if run_import "$remote" missing-build.sh "$fixture/build-fail" "$first" >"$fixture/build.log" 2>&1; then
+    echo "failed build unexpectedly succeeded" >&2
+    exit 1
+fi
+grep -q "build imported repository" "$fixture/build.log"
+test ! -e "$fixture/build-fail/fixture"
+
+# Separate processes serialize a shared fresh target.
+run_import "$remote" '' "$fixture/concurrent" "$first" &
+pid1=$!
+run_import "$remote" '' "$fixture/concurrent" "$first" &
+pid2=$!
+wait "$pid1"
+wait "$pid2"
+test "$(git -C "$fixture/concurrent/fixture" rev-parse HEAD)" = "$first"
+
+# Legacy URL-only behavior still clones a local deterministic remote.
+mkdir -p "$fixture/legacy"
+(cd "$fixture/legacy" && swipl -q -g "consult('$project_dir/lib/lib_import.pl'),'git-import!'('$remote',true),halt")
+test -d "$fixture/legacy/repos/fixture/.git"
+
+echo "commit-pinned git-import tests passed"


### PR DESCRIPTION
## Summary

Extract the non-import changes that were previously bundled into #195 so the import overhaul can be reviewed independently.

This branch contains four separate, pre-existing improvements:

- evaluate function expressions used as the target space of `add-atom` and `remove-atom`;
- add `first`, `second`, `cns`, and `flip` pair helpers to `lib_roman`;
- handle CLI silent flags separately from the input filename;
- raise the embedded SWI-Prolog stack limit for Python API users.

## Validation

```
sh run.sh examples/add_atom_fun_space.metta --silent
sh run.sh examples/lib_roman_pair_helpers.metta --silent
cd python && uv run pytest tests/test_petta.py
```

Both focused MeTTa examples passed and the Python suite reported `3 passed`. `git diff --check` is clean.
