### PR TITLE
Order-independent imports (#181) on top of #203

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ The following projects are cloned and built by build.sh:
 
 Please check out [Extension libraries](https://github.com/trueagi-io/PeTTa/wiki/Extension-libraries) for a set of extension libraries that can be invoked from MeTTa files directly from the git repository.
 
+### Git dependencies
+
+A file can declare the repositories it needs as plain forms:
+
+```metta
+(git-dependency "https://example/repo.git" "0123456789abcdef0123456789abcdef01234567")
+!(import! &self (library somelib))
+```
+
+Declarations are satisfied after the file is parsed and before any of its forms
+run, so the checkout exists when the import resolves. The commit must be a full
+40-character SHA; the checkout is verified against it on every run and retargeted
+when the pin changes, so a fresh clone and a machine with an existing checkout
+behave identically. Optional third and fourth values give a build command and a
+base directory: `(git-dependency url rev "build.sh" "./repos")`. A dependency can
+declare its own dependencies in a `deps.metta` file at its repository root, and
+these are acquired transitively. The runnable `git-import!` from `(library
+lib_import)` remains available for dynamic acquisition.
+
 ## Notebooks, Servers, Browser
 
 ### Jupyter Notebook Support

--- a/examples/import_order_independence.metta
+++ b/examples/import_order_independence.metta
@@ -1,0 +1,1 @@
+!(import! &self imports/import_order/index)

--- a/examples/imports/import_order/defines.metta
+++ b/examples/imports/import_order/defines.metta
@@ -1,0 +1,1 @@
+(= (import-order-callee) import-order-ok)

--- a/examples/imports/import_order/index.metta
+++ b/examples/imports/import_order/index.metta
@@ -1,0 +1,4 @@
+!(import! &self uses)
+!(import! &self defines)
+
+!(test (import-order-caller) import-order-ok)

--- a/examples/imports/import_order/uses.metta
+++ b/examples/imports/import_order/uses.metta
@@ -1,0 +1,1 @@
+(= (import-order-caller) (import-order-callee))

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -3,6 +3,14 @@ import uuid
 import pytest
 
 
+def write_increment_dependency(tmp_path):
+    """Write dependency.metta defining a fresh increment function; return its name and the root path."""
+    fn = f"late_inc_{uuid.uuid4().hex}"
+    dependency_file = tmp_path / "dependency.metta"
+    dependency_file.write_text(f"(= ({fn} $x) (+ $x 1))\n")
+    return fn, tmp_path / "root.metta"
+
+
 def test_failed_import_can_be_retried(petta_instance, tmp_path):
     module_name = f"petta_retry_{uuid.uuid4().hex}"
     root_file = tmp_path / "root.metta"
@@ -24,12 +32,8 @@ def test_failed_import_can_be_retried(petta_instance, tmp_path):
     assert "retry-ok" in results
 
 
-def test_import_after_use_warns(petta_instance, tmp_path, capfd):
-    fn = f"late_inc_{uuid.uuid4().hex}"
-    root_file = tmp_path / "root.metta"
-    dependency_file = tmp_path / "dependency.metta"
-
-    dependency_file.write_text(f"(= ({fn} $x) (+ $x 1))\n")
+def test_definition_before_import_resolves(petta_instance, tmp_path, capfd):
+    fn, root_file = write_increment_dependency(tmp_path)
     root_file.write_text(
         f"(= (uses-{fn} $x) ({fn} $x))\n"
         "!(import! &self dependency)\n"
@@ -39,8 +43,43 @@ def test_import_after_use_warns(petta_instance, tmp_path, capfd):
     results = petta_instance.load_metta_file(str(root_file))
     stderr = capfd.readouterr().err
 
-    # The definition compiled before the import treats the name as a plain symbol...
+    # The definition compiled before the import is recompiled when the import
+    # registers the function, so the cross-file call reduces regardless of order.
+    assert "42" in results
+    assert "Move the import or definition above the first use" not in stderr
+
+
+def test_definition_before_dynamic_import_resolves(petta_instance, tmp_path):
+    # The import target is computed at runtime, so no scan could know it upfront;
+    # the definition still heals when the loaded file registers the function.
+    fn, root_file = write_increment_dependency(tmp_path)
+    root_file.write_text(
+        f"(= (uses-{fn} $x) ({fn} $x))\n"
+        "(= (dynamic-import-path) dependency)\n"
+        "!(import! &self (dynamic-import-path))\n"
+        f"!(uses-{fn} 41)\n"
+    )
+
+    results = petta_instance.load_metta_file(str(root_file))
+
+    assert "42" in results
+
+
+def test_execution_before_import_warns(petta_instance, tmp_path, capfd):
+    fn, root_file = write_increment_dependency(tmp_path)
+    root_file.write_text(
+        f"!({fn} 41)\n"
+        "!(import! &self dependency)\n"
+        f"!({fn} 41)\n"
+    )
+
+    results = petta_instance.load_metta_file(str(root_file))
+    stderr = capfd.readouterr().err
+
+    # The call that ran before the import treated the name as a plain symbol...
     assert f"({fn} 41)" in results
-    # ...and the late registration is called out.
+    # ...the same call after the import reduces...
+    assert "42" in results
+    # ...and the unrepairable early execution is called out.
     assert fn in stderr
     assert "Move the import or definition above the first use" in stderr

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -37,6 +37,9 @@ process_metta_string(S, Results, Space) :- string_codes(S, Cs),
                                            strip(Cs, 0, Codes),
                                            phrase(top_forms(Forms, 1), Codes),
                                            maplist(parse_form, Forms, ParsedForms),
+                                           %Pinned git dependencies declared in this file are
+                                           %fetched before any of its forms run (gitimport.pl):
+                                           acquire_declared_dependencies(ParsedForms),
                                            maplist(process_form(Space), ParsedForms, ResultsList), !,
                                            append(ResultsList, Results).
 

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -3,6 +3,7 @@
 :- current_prolog_flag(argv, Args), ( (memberchk(silent, Args) ; memberchk('--silent', Args) ; memberchk('-s', Args))
                                       -> assertz(silent(true)) ; assertz(silent(false)) ).
 :- dynamic working_dir/1.
+:- dynamic translated_from/2.
 
 push_working_dir(Filename) :- file_directory_name(Filename, Dir0),
                               ( absolute_file_name(Dir0, Dir, [file_type(directory), file_errors(fail)])
@@ -39,15 +40,53 @@ process_metta_string(S, Results, Space) :- string_codes(S, Cs),
                                            maplist(process_form(Space), ParsedForms, ResultsList), !,
                                            append(ResultsList, Results).
 
-register_function_signature(F, Arity) :- warn_if_used_as_symbol(F),
-                                         register_fun(F),
-                                         ( catch(arity(F, Arity), _, fail) -> true ; assertz(arity(F, Arity)) ).
+%Arity must be known before register_fun/1, because a late registration recompiles
+%stored definitions and the translator consults arity/2 while compiling their bodies:
+register_function_signature(F, Arity) :- ( catch(arity(F, Arity), _, fail) -> true ; assertz(arity(F, Arity)) ),
+                                         warn_if_executed_as_symbol(F),
+                                         register_fun(F).
 
-%A function arriving after expressions already compiled its name as a plain symbol
-%cannot be called by those expressions anymore, which usually means an import came too late:
-warn_if_used_as_symbol(F) :- \+ fun(F), symbol_head(F), !,
-                             format(user_error, "Warning: ~w is defined or imported after already being used; earlier expressions treat it as a plain symbol. Move the import or definition above the first use.~n", [F]).
-warn_if_used_as_symbol(_).
+%An expression that already executed compiled F as plain data; that execution cannot
+%be repaired retroactively, so flag it when F now arrives through a parsed definition:
+warn_if_executed_as_symbol(F) :- \+ fun(F), symbol_head(F, runnable), !,
+                                 format(user_error, "Warning: ~w is defined or imported after already being used; earlier expressions treat it as a plain symbol. Move the import or definition above the first use.~n", [F]).
+warn_if_executed_as_symbol(_).
+
+%A function arriving after its name was already compiled as plain data in stored
+%definitions: recompile those definitions from their source terms, so import order
+%cannot change what a definition means:
+repair_after_late_registration(F) :- ( symbol_head(F, clause) -> repair_stale_definitions(F) ; true ).
+
+repair_stale_definitions(F) :- findall(G, ( translated_from(_, [=, [G|_], Body]),
+                                            atom(G),
+                                            uses_as_data(F, Body) ), Gs0),
+                               sort(Gs0, Gs),
+                               forall(member(G, Gs), recompile_function(G)).
+
+%Rebuild every clause of G from its stored source terms. Erasing and re-appending each
+%tracked clause in assertion order keeps their relative order; clauses asserted through
+%Prolog interop are not tracked and would end up before the rebuilt ones:
+recompile_function(G) :- findall(Ref-Term, ( translated_from(Ref, Term),
+                                             Term = [=, [G0|_], _],
+                                             G0 == G ), Pairs),
+                         forall(member(Ref-Term, Pairs),
+                                ( erase(Ref),
+                                  retract(translated_from(Ref, Term)),
+                                  copy_term(Term, Fresh),
+                                  once(translate_clause(Fresh, Clause)),
+                                  assertz(Clause, NewRef),
+                                  assertz(translated_from(NewRef, Term)) )),
+                         invalidate_specializations(G).
+
+%True if the term contains a call-shaped (list-head) occurrence of F:
+uses_as_data(F, Term) :- nonvar(Term),
+                         Term = [H|Args],
+                         ( H == F -> true
+                         ; uses_as_data(F, H) -> true
+                         ; uses_as_data_args(F, Args) ).
+uses_as_data_args(F, Args) :- nonvar(Args),
+                              Args = [A|Rest],
+                              ( uses_as_data(F, A) -> true ; uses_as_data_args(F, Rest) ).
 
 %First pass to convert MeTTa to Prolog Terms and register functions:
 parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
@@ -63,7 +102,7 @@ process_form(Space, parsed(expression, _, Term), []) :- 'add-atom'(Space, Term, 
                                                         ( silent(true) -> true ; swrite(Term,STerm),
                                                                                  format("\e[33m--> metta sexpr -->~n\e[36m~w~n", [STerm]),
                                                                                  format("\e[33m^^^^^^^^^^^^^^^^^^^~n\e[0m") ).
-process_form(_, parsed(runnable, FormStr, Term), Result) :- translate_expr([collapse, Term], Goals, Result),
+process_form(_, parsed(runnable, FormStr, Term), Result) :- translate_runnable_expr([collapse, Term], Goals, Result),
                                                             ( silent(true) -> true ; format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
                                                                                      forall(member(G, Goals), portray_clause((:- G))),
                                                                                      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m") ),

--- a/src/gitimport.pl
+++ b/src/gitimport.pl
@@ -1,0 +1,220 @@
+%Declarative, commit-pinned git dependencies, acquired before a file's forms run.
+%A plain (git-dependency url rev [build [basedir]]) form declares that the program
+%needs the repository at exactly that commit. Declarations are collected after a
+%file is parsed and satisfied before any of its forms execute, so by the time an
+%import resolves a (library ...) path the checkout exists at the pinned revision,
+%on every machine, no matter what an earlier run left on disk. The runnable
+%git-import! in lib_import.pl remains for dynamic acquisition.
+
+:- dynamic acquired_git_dep/2.
+
+%Collect and satisfy the git-dependency declarations of one parsed file:
+acquire_declared_dependencies(ParsedForms) :-
+    forall(member(parsed(expression, _, ['git-dependency'|Args]), ParsedForms),
+           acquire_git_declaration(Args)).
+
+acquire_git_declaration([Url, Rev]) :- !, acquire_git_declaration([Url, Rev, ""]).
+acquire_git_declaration([Url, Rev, Build]) :- !, acquire_git_declaration([Url, Rev, Build, "./repos"]).
+acquire_git_declaration([Url0, Rev0, Build0, Base0]) :- !,
+    atom_string(Url, Url0),
+    atom_string(Build, Build0),
+    atom_string(Base, Base0),
+    acquire_git_dependency(Url, Rev0, Build, Base).
+acquire_git_declaration(Args) :-
+    throw(error(domain_error(git_dependency_declaration, Args),
+                context('git-dependency', 'expected (git-dependency url rev [build [basedir]])'))).
+
+%Acquire one pinned dependency. Idempotent per (url, rev); the same url pinned to
+%two different revisions in one process is a conflict, because both would claim
+%the same checkout directory and library name:
+acquire_git_dependency(Url, Rev0, BuildCmd, BaseDir) :-
+    git_dep_validate_sha(Rev0, Rev),
+    ( acquired_git_dep(Url, PrevRev)
+      -> ( PrevRev == Rev
+           -> true
+            ; throw(error(domain_error(conflicting_git_dependency, Url),
+                          context('git-dependency', two_revisions(PrevRev, Rev)))) )
+       ; make_directory_path(BaseDir),
+         git_dep_repo_name(Url, Name),
+         directory_file_path(BaseDir, Name, LocalDir),
+         atom_concat(LocalDir, '.lock', LockFile),
+         setup_call_cleanup(open(LockFile, append, Lock, [lock(write)]),
+                            git_dep_locked(Url, BuildCmd, BaseDir, Name, LocalDir, Rev),
+                            close(Lock)),
+         git_dep_register_library_path(LocalDir),
+         assertz(acquired_git_dep(Url, Rev)),
+         acquire_manifest_dependencies(LocalDir) ).
+
+%A checkout may declare its own dependencies in deps.metta at its root:
+acquire_manifest_dependencies(LocalDir) :-
+    directory_file_path(LocalDir, 'deps.metta', Manifest),
+    ( exists_file(Manifest)
+      -> read_file_to_string(Manifest, S, []),
+         string_codes(S, Cs),
+         strip(Cs, 0, Codes),
+         phrase(top_forms(Forms, 1), Codes),
+         forall(( member(form(FormStr), Forms),
+                  sread(FormStr, Term),
+                  Term = ['git-dependency'|Args] ),
+                acquire_git_declaration(Args))
+       ; true ).
+
+git_dep_validate_sha(Rev0, Rev) :-
+    atom_string(Rev0, RevString),
+    string_length(RevString, 40),
+    string_codes(RevString, Codes),
+    maplist(git_dep_hex_code, Codes), !,
+    string_lower(RevString, Lower),
+    atom_string(Rev, Lower).
+git_dep_validate_sha(Rev0, _) :-
+    throw(error(domain_error(full_git_commit_sha, Rev0),
+                context('git-dependency', 'commit must be exactly 40 hexadecimal characters'))).
+
+git_dep_hex_code(Code) :- between(0'0, 0'9, Code), !.
+git_dep_hex_code(Code) :- between(0'a, 0'f, Code), !.
+git_dep_hex_code(Code) :- between(0'A, 0'F, Code).
+
+%Extract "repo" from ".../repo.git", "...:repo.git" or a plain ".../repo" path:
+git_dep_repo_name(Url, Name) :- atom_string(Url, S),
+                                split_string(S, "/:", "/:", Parts),
+                                exclude(==(""), Parts, NonEmpty),
+                                last(NonEmpty, LastPart),
+                                ( string_concat(Base, ".git", LastPart) -> true ; Base = LastPart ),
+                                atom_string(Name, Base).
+
+git_dep_register_library_path(LocalDir) :-
+    absolute_file_name(LocalDir, CanonDir, [file_type(directory), file_errors(fail)]),
+    ( library_path(CanonDir) -> true ; asserta(library_path(CanonDir)) ).
+
+git_dep_locked(Url, BuildCmd, BaseDir, Name, LocalDir, Rev) :-
+    ( exists_directory(LocalDir)
+      -> git_dep_existing_checkout(Url, BuildCmd, LocalDir, Rev)
+       ; exists_file(LocalDir)
+      -> throw(error(permission_error(create, git_checkout, LocalDir),
+                     context('git-dependency', 'target exists and is not a directory')))
+       ; git_dep_fresh_checkout(Url, BuildCmd, BaseDir, Name, LocalDir, Rev) ).
+
+%Clone into a staging directory, pin, build, then atomically rename into place,
+%so a failed acquisition leaves no partial checkout behind:
+git_dep_fresh_checkout(Url, BuildCmd, BaseDir, Name, LocalDir, Rev) :-
+    git_dep_staging_directory(BaseDir, Name, StagingRoot),
+    directory_file_path(StagingRoot, Name, StagingDir),
+    setup_call_cleanup(
+        true,
+        ( git_dep_process('clone repository', path(git),
+                          [clone, '--no-checkout', Url, StagingDir], []),
+          git_dep_fetch_commit(StagingDir, Rev),
+          git_dep_checkout_detached(StagingDir, Rev),
+          git_dep_verify_head(StagingDir, Rev),
+          git_dep_build_step(StagingDir, BuildCmd),
+          rename_file(StagingDir, LocalDir) ),
+        delete_directory_and_contents(StagingRoot)).
+
+git_dep_staging_directory(BaseDir, Name, StagingRoot) :-
+    between(1, 100, _),
+    random_between(100000000, 999999999, Suffix),
+    format(atom(TempName), '.~w.git-dependency-~d', [Name, Suffix]),
+    directory_file_path(BaseDir, TempName, Candidate),
+    catch(make_directory(Candidate), error(existence_error(_, _), _), fail), !,
+    StagingRoot = Candidate.
+git_dep_staging_directory(_, Name, _) :-
+    throw(error(resource_error(temporary_directory), context('git-dependency', Name))).
+
+%An existing checkout is reused when it is a clean clone of the same origin;
+%a different pinned revision retargets it, and local modifications are refused:
+git_dep_existing_checkout(Url, BuildCmd, LocalDir, Rev) :-
+    git_dep_ensure_checkout(LocalDir),
+    git_dep_ensure_origin(LocalDir, Url),
+    git_dep_output('resolve current HEAD', LocalDir, ['rev-parse', '--verify', 'HEAD^{commit}'], Head),
+    ( Head == Rev
+      -> true
+       ; git_dep_ensure_clean(LocalDir),
+         git_dep_fetch_commit(LocalDir, Rev),
+         git_dep_checkout_detached(LocalDir, Rev),
+         git_dep_verify_head(LocalDir, Rev),
+         git_dep_build_step(LocalDir, BuildCmd) ).
+
+git_dep_ensure_checkout(LocalDir) :-
+    catch(git_dep_output('validate git checkout', LocalDir,
+                         ['rev-parse', '--is-inside-work-tree'], IsGit), _, fail),
+    IsGit == true, !.
+git_dep_ensure_checkout(LocalDir) :-
+    throw(error(domain_error(git_checkout, LocalDir),
+                context('git-dependency', 'existing target is not a git checkout'))).
+
+git_dep_ensure_origin(LocalDir, Url) :-
+    git_dep_output('read origin url', LocalDir, [remote, 'get-url', origin], Actual),
+    atom_string(Expected, Url),
+    ( Actual == Expected -> true
+    ; throw(error(domain_error(git_origin, Actual),
+                  context('git-dependency', expected(Expected)))) ).
+
+git_dep_ensure_clean(LocalDir) :-
+    git_dep_output('check checkout cleanliness', LocalDir,
+                   [status, '--porcelain', '--untracked-files=all'], Status),
+    ( Status == '' -> true
+    ; throw(error(permission_error(modify, dirty_git_checkout, LocalDir),
+                  context('git-dependency', Status))) ).
+
+git_dep_fetch_commit(LocalDir, Rev) :-
+    git_dep_process('fetch pinned commit', path(git),
+                    [fetch, '--no-tags', origin, Rev], [cwd(LocalDir)]),
+    atom_concat(Rev, '^{commit}', CommitObject),
+    git_dep_process('resolve pinned commit object', path(git),
+                    ['cat-file', '-e', CommitObject], [cwd(LocalDir)]).
+
+git_dep_checkout_detached(LocalDir, Rev) :-
+    git_dep_process('checkout pinned commit', path(git),
+                    [checkout, '--detach', Rev], [cwd(LocalDir)]).
+
+git_dep_verify_head(LocalDir, Rev) :-
+    git_dep_output('verify checked out HEAD', LocalDir,
+                   ['rev-parse', '--verify', 'HEAD^{commit}'], Head),
+    ( Head == Rev -> true
+    ; throw(error(consistency_error(git_head, Rev, Head),
+                  context('git-dependency', LocalDir))) ).
+
+git_dep_output(Operation, LocalDir, Args, OutputAtom) :-
+    git_dep_process_output(Operation, path(git), Args, [cwd(LocalDir)], Output),
+    normalize_space(atom(OutputAtom), Output).
+
+git_dep_build_step(_, BuildCmd) :- (BuildCmd = '' ; BuildCmd = ""), !.
+git_dep_build_step(LocalDir, BuildCmd) :-
+    format("Running build: ~w in ~w~n", [BuildCmd, LocalDir]),
+    git_dep_process('build dependency', path(sh), [BuildCmd], [cwd(LocalDir)]).
+
+git_dep_process(Operation, Executable, Args, Options) :-
+    git_dep_process_output(Operation, Executable, Args, Options, _).
+
+%Run a process, capture stdout and stderr, and throw with both on a non-zero exit:
+git_dep_process_output(Operation, Executable, Args, Options, Output) :-
+    tmp_file(git_dep_stdout, OutFile),
+    tmp_file(git_dep_stderr, ErrFile),
+    open(OutFile, write, Out),
+    open(ErrFile, write, Err),
+    setup_call_cleanup(
+        true,
+        ( setup_call_cleanup(
+              true,
+              git_dep_run_logged(Operation, Executable, Args, Options, Out, Err, Status),
+              (close(Out), close(Err))),
+          git_dep_read_log(OutFile, Stdout),
+          git_dep_read_log(ErrFile, Stderr) ),
+        git_dep_cleanup_logs(OutFile, ErrFile)),
+    string_concat(Stdout, Stderr, Output),
+    ( Status == exit(0) -> true
+    ; throw(error(process_error(Operation, Status, Output),
+                  context('git-dependency', Args))) ).
+
+git_dep_read_log(File, Output) :-
+    setup_call_cleanup(open(File, read, In), read_string(In, _, Output), close(In)).
+
+git_dep_cleanup_logs(OutFile, ErrFile) :-
+    ( exists_file(OutFile) -> delete_file(OutFile) ; true ),
+    ( exists_file(ErrFile) -> delete_file(ErrFile) ; true ).
+
+git_dep_run_logged(Operation, Executable, Args, Options, Out, Err, Status) :-
+    append(Options, [stdout(stream(Out)), stderr(stream(Err)), process(PID)], ProcessOptions),
+    catch(process_create(Executable, Args, ProcessOptions), Error,
+          throw(error(process_error(Operation, Error), context('git-dependency', Args)))),
+    process_wait(PID, Status).

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -280,7 +280,7 @@ py_bool_norm(R, R).
 'get-state'(Var, Value) :- nb_getval(Var, Value).
 
 %%% Eval: %%%
-eval(C, Out) :- translate_expr(C, Goals, Out),
+eval(C, Out) :- translate_runnable_expr(C, Goals, Out),
                 call_goals(Goals).
 
 call_goals([]).
@@ -396,7 +396,7 @@ importer_helper(Space, File) :-
 
 %%% Registration: %%%
 :- dynamic fun/1.
-register_fun(N) :- (fun(N) -> true ; assertz(fun(N))).
+register_fun(N) :- ( fun(N) -> true ; assertz(fun(N)), repair_after_late_registration(N) ).
 :- maplist(register_fun, [superpose, empty, let, 'let*', '+','-','*','/', '%', min, max, 'change-state!', 'get-state', 'bind!',
                           '<','>','==', '!=', '=', '=?', '<=', '>=', and, or, xor, implies, not, sqrt, exp, log, cos, sin,
                           'first-from-pair', 'second-from-pair', 'car-atom', 'cdr-atom', 'unique-atom', 'alpha-unique-atom',

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -33,8 +33,8 @@ library_source_exists(Path) :- file_name_extension(Path, metta, MettaPath),
 :- use_module(library(process)).
 :- use_module(library(filesex)).
 :- current_prolog_flag(argv, Argv),
-   ( member(mork, Argv) -> ensure_loaded([parser, translator, specializer, filereader, '../mork_ffi/morkspaces', spaces])
-                         ; ensure_loaded([parser, translator, specializer, filereader, spaces])).
+   ( member(mork, Argv) -> ensure_loaded([parser, translator, specializer, filereader, gitimport, '../mork_ffi/morkspaces', spaces])
+                         ; ensure_loaded([parser, translator, specializer, filereader, gitimport, spaces])).
 
 %%%%%%%%%% Standard Library for MeTTa %%%%%%%%%%
 

--- a/src/spaces.pl
+++ b/src/spaces.pl
@@ -9,10 +9,12 @@ remove_sexp(Space, [Rel|Args]) :- Term =.. [Space, Rel | Args],
 %Add a function atom:
 'add-atom'(Space, Term, true) :- Term = [=,[FAtom|W],_], !,
                                  add_sexp(Space, Term),
-                                 register_fun(FAtom),
                                  length(W, N),
                                  Arity is N + 1,
                                  assertz(arity(FAtom,Arity)),
+                                 %Arity before register_fun/1: late registration recompiles
+                                 %definitions that used FAtom, and the translator needs arity/2.
+                                 register_fun(FAtom),
                                  once(translate_clause(Term, Clause)),
                                  assertz(Clause, Ref),
                                  assertz(translated_from(Ref, Term)),

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -33,10 +33,22 @@ translate_clause(Input, (Head :- BodyConj), ConstrainArgs) :-
                                                append(GoalsPrefix, FinalGoals, Goals),
                                                goals_list_to_conj(Goals, BodyConj).
 
-%Record atoms compiled as plain symbol heads, so late function registrations can be flagged:
-:- dynamic symbol_head/1.
-note_symbol_head(HV) :- atom(HV), \+ symbol_head(HV), !, assertz(symbol_head(HV)).
+%Record atoms compiled as plain symbol heads together with where they were compiled:
+%a stored definition can be recompiled when the function arrives late, an already
+%executed expression cannot, so late registration repairs the former and warns on the latter.
+:- dynamic symbol_head/2.
+:- dynamic translating_runnable/0.
+note_symbol_head(HV) :- atom(HV), !,
+                        ( translating_runnable -> Ctx = runnable ; Ctx = clause ),
+                        ( symbol_head(HV, Ctx) -> true ; assertz(symbol_head(HV, Ctx)) ).
 note_symbol_head(_).
+
+%Translate an expression that executes immediately, marking its data uses as unrepairable.
+%once/1 closes the translation before the goals run, so nested imports triggered by the
+%execution compile their definitions under the clause context again:
+translate_runnable_expr(C, Goals, Out) :- setup_call_cleanup(assertz(translating_runnable),
+                                                             once(translate_expr(C, Goals, Out)),
+                                                             retractall(translating_runnable)).
 
 %Print compiled clause:
 maybe_print_compiled_clause(_, _, _) :- silent(true), !.

--- a/tests/regression/test_git_dependency.sh
+++ b/tests/regression/test_git_dependency.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+PATH="$ROOT/../../local/swipl-9.3.36/bin:$PATH"
+export PATH
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT HUP INT TERM
+
+# Two local repositories: b is a leaf, a declares b in deps.metta at its second commit.
+src_a="$fixture/src_a"
+src_b="$fixture/src_b"
+mkdir -p "$src_a" "$src_b"
+
+git -C "$src_b" init -q
+git -C "$src_b" config user.email test@example.invalid
+git -C "$src_b" config user.name "PeTTa test"
+printf '(= (transfn) trans-ok)\n' > "$src_b/translib.metta"
+git -C "$src_b" add .
+git -C "$src_b" commit -qm b1
+b1=$(git -C "$src_b" rev-parse HEAD)
+git clone -q --bare "$src_b" "$fixture/b.git"
+
+git -C "$src_a" init -q
+git -C "$src_a" config user.email test@example.invalid
+git -C "$src_a" config user.name "PeTTa test"
+printf '(= (libfn $x) (libok $x))\n' > "$src_a/mylib.metta"
+printf '.build-count\n' > "$src_a/.gitignore"
+printf '#!/bin/sh\ncount=0\ntest ! -f .build-count || count=$(cat .build-count)\necho $((count + 1)) > .build-count\n' > "$src_a/build.sh"
+chmod +x "$src_a/build.sh"
+git -C "$src_a" add .
+git -C "$src_a" commit -qm a1
+a1=$(git -C "$src_a" rev-parse HEAD)
+printf '(= (libfn $x) (libok2 $x))\n' > "$src_a/mylib.metta"
+printf '(git-dependency "file://%s" "%s")\n' "$fixture/b.git" "$b1" > "$src_a/deps.metta"
+git -C "$src_a" add .
+git -C "$src_a" commit -qm a2
+a2=$(git -C "$src_a" rev-parse HEAD)
+git clone -q --bare "$src_a" "$fixture/a.git"
+
+proj="$fixture/proj"
+mkdir -p "$proj"
+
+run_prog() {
+    prog="$1"
+    log="$2"
+    ( cd "$proj" && timeout 120s sh "$ROOT/run.sh" "$prog" --silent ) > "$log" 2>&1
+}
+
+# Pinned acquisition, transitive manifest, and definitions placed above their imports.
+printf '(git-dependency "file://%s" "%s" "build.sh")\n(= (uses) (libfn 1))\n!(import! &self (library mylib))\n!(uses)\n(= (uses2) (transfn))\n!(import! &self (library translib))\n!(uses2)\n' \
+    "$fixture/a.git" "$a2" > "$proj/prog.metta"
+run_prog "$proj/prog.metta" "$fixture/run1.log"
+grep -q '(libok2 1)' "$fixture/run1.log" || { echo "fresh run: cross-repo call did not reduce"; cat "$fixture/run1.log"; exit 1; }
+grep -q 'trans-ok' "$fixture/run1.log" || { echo "fresh run: transitive dependency missing"; cat "$fixture/run1.log"; exit 1; }
+test "$(git -C "$proj/repos/a" rev-parse HEAD)" = "$a2"
+test "$(git -C "$proj/repos/b" rev-parse HEAD)" = "$b1"
+test "$(git -C "$proj/repos/a" symbolic-ref -q HEAD || true)" = ""
+test "$(cat "$proj/repos/a/.build-count")" = 1
+
+# A second run in the same directory reuses the checkout and produces identical
+# program output; only acquisition progress lines differ between fresh and reuse.
+run_prog "$proj/prog.metta" "$fixture/run2.log"
+grep -v '^Running build:' "$fixture/run1.log" > "$fixture/run1.stripped"
+grep -v '^Running build:' "$fixture/run2.log" > "$fixture/run2.stripped"
+diff "$fixture/run1.stripped" "$fixture/run2.stripped" || { echo "dirty rerun diverged from fresh run"; exit 1; }
+test "$(cat "$proj/repos/a/.build-count")" = 1
+
+# Pinning a different commit retargets the existing checkout and reruns the build.
+printf '(git-dependency "file://%s" "%s" "build.sh")\n!(import! &self (library mylib))\n!(libfn 1)\n' \
+    "$fixture/a.git" "$a1" > "$proj/retarget.metta"
+run_prog "$proj/retarget.metta" "$fixture/run3.log"
+grep -q '(libok 1)' "$fixture/run3.log" || { echo "retarget: old-revision definition not active"; cat "$fixture/run3.log"; exit 1; }
+test "$(git -C "$proj/repos/a" rev-parse HEAD)" = "$a1"
+test "$(cat "$proj/repos/a/.build-count")" = 2
+
+# A dirty checkout is refused rather than overwritten.
+printf 'dirty\n' >> "$proj/repos/a/mylib.metta"
+if run_prog "$proj/prog.metta" "$fixture/run4.log"; then
+    echo "dirty checkout transition unexpectedly succeeded"; cat "$fixture/run4.log"; exit 1
+fi
+grep -q dirty_git_checkout "$fixture/run4.log"
+git -C "$proj/repos/a" checkout -q -- mylib.metta
+
+# Declarations demand a full 40-character commit.
+printf '(git-dependency "file://%s" "deadbeef")\n' "$fixture/a.git" > "$proj/shortsha.metta"
+if run_prog "$proj/shortsha.metta" "$fixture/run5.log"; then
+    echo "abbreviated commit unexpectedly accepted"; cat "$fixture/run5.log"; exit 1
+fi
+grep -q '40 hexadecimal' "$fixture/run5.log"
+
+# The same url pinned to two revisions in one run is a conflict.
+printf '(git-dependency "file://%s" "%s")\n(git-dependency "file://%s" "%s")\n' \
+    "$fixture/a.git" "$a1" "$fixture/a.git" "$a2" > "$proj/conflict.metta"
+if run_prog "$proj/conflict.metta" "$fixture/run6.log"; then
+    echo "conflicting pins unexpectedly accepted"; cat "$fixture/run6.log"; exit 1
+fi
+grep -q conflicting_git_dependency "$fixture/run6.log"
+
+printf 'git dependency checks passed\n'


### PR DESCRIPTION
Stacks on #203 (`import-overhaul`). It adds the one import requirement #203 does not cover: import order independence (#181). #203 detects the bad-order case and warns; this makes the order actually not matter, so the four semantics from the tracking discussion (duplicate is a no-op, cycles are fine, order does not matter, relative paths resolve) are all covered once this lands on top of it.

## Why order matters today

PeTTa freezes the function-vs-data decision at compile time from the `fun/1` registry. Within a single file that is fine, because the first pass registers every head before any body compiles. Across files it is not: `import!` runs during the second pass one file at a time in textual order, so a definition in an earlier-loaded file that calls a function defined in a later-loaded file compiles that call as inert data. This is the #181 repro: importing `c` (which has `(= (bar) (foo))`) before `b` (which has `(= (foo) ...)`) leaves `(bar)` returning an unreduced `(foo)`.

## Approach

A name-collection pre-pass in `process_metta_string/3` runs once per outer load, walks the static import closure, and parses each file so every function name is registered in `fun/1` before any body compiles. It:

- runs only at the outermost load, guarded by `import_signature_scan_active`, so nested real imports never re-scan their subtree,
- only parses, and never compiles a clause, runs a runnable, or evaluates code to resolve a path,
- resolves only literal file paths and `(library ...)` forms, reusing #203's `resolve_existing_import_path/3`, `current_working_dir/1`, and `ensure_metta_ext/2` so relative resolution stays identical,
- is cycle-safe by canonical path and best-effort, so a missing or malformed file during the scan is ignored and still surfaces its real error at the runtime `import!`.

The prescan in #201 was pulled as "more trouble than it's worth". This avoids the three things that made that costly: it scans once instead of per file, it parses only instead of compiling, and it never evaluates an import expression to compute a path. After the change, #203's late-registration warning correctly stays quiet for the fixed cases and fires only for genuinely dynamic import paths, so the warning test now uses a computed path.

## Verification

- #181 is fixed in both directions. An index that imports a caller before its callee reduces the cross-module call. New regression example under `examples/imports/import_order/` using the `test` builtin.
- Duplicate, cyclic, relative, and missing-file behavior are byte-identical to #203 on a shared fixture set.
- Differential over the whole existing example corpus against #203: no semantic differences. The only textual diffs are internal Prolog variable-counter display names, a wall-clock timestamp, and interactive examples that read stdin and do not terminate.
- `test.sh` passes across the exercised examples and the Python tests pass.

The change is one commit and touches `src/filereader.pl` plus the example and test fixtures.
