### PR TITLE
Fix library call semantics

### DIFF
--- a/examples/git_import.metta
+++ b/examples/git_import.metta
@@ -3,7 +3,7 @@
 
 !(git-import! "https://github.com/rTreutlein/test_metta_lib.git")
 
-!(import! &self (library test))
+!(import! &self (library test_metta_lib test))
 
 !(test (mytest 10) 10)
 

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -1,10 +1,10 @@
 %%%%%%%%%% Dependencies %%%%%%%%%%
-library(X, Path) :- library_path(Base), atomic_list_concat([Base, '/', X], Path).
+library(X, Path) :- standard_library_path(Base), atomic_list_concat([Base, '/', X], Path).
 library(X, Y, Path) :- library_path(Base), atom_concat(_, X, Base), atomic_list_concat([Base, '/', Y], Path).
 :- prolog_load_context(directory, Source),
    directory_file_path(Source, '..', Parent),
    directory_file_path(Parent, 'lib', LibPath),
-   asserta(library_path(LibPath)).
+   asserta(standard_library_path(LibPath)).
 :- autoload(library(uuid)).
 :- use_module(library(random)).
 :- use_module(library(janus)).

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -1,6 +1,6 @@
 %%%%%%%%%% Dependencies %%%%%%%%%%
 library(X, Path) :- library_path(Base), atomic_list_concat([Base, '/', X], Path).
-library(X, Y, Path) :- library_path(Base), atomic_list_concat([Base, '/../', X, '/', Y], Path).
+library(X, Y, Path) :- library_path(Base), atom_concat(_, X, Base), atomic_list_concat([Base, '/', Y], Path).
 :- prolog_load_context(directory, Source),
    directory_file_path(Source, '..', Parent),
    directory_file_path(Parent, 'lib', LibPath),


### PR DESCRIPTION
Implementing approach suggested in #206:
Change the `library/2` definition to use only the `<PeTTa root>/lib` path and change `library/3` definition by adding the check the `library_path` is a path to the `X` (first argument of the `library`). 