### PR TITLE
Fix compile-time divergence in the specializer

### DIFF
--- a/examples/specialize_recursive_wrap.metta
+++ b/examples/specialize_recursive_wrap.metta
@@ -1,0 +1,9 @@
+; A recursive call that wraps its higher-order argument used to diverge at
+; COMPILE time: each nested specialization built a bigger key
+; (partial(twice,[partial(twice,[derive])]) ...) and never terminated.
+; Re-specializing a function already being specialized is now refused; the
+; inner call compiles unspecialized and translation terminates.
+(= (derive $g) $g)
+(= (twice $r $g) ($r ($r $g)))
+(= (evolve $r $n $g) (if (== $n 0) $g (evolve (twice $r) (- $n 1) $g)))
+!(test (evolve derive 2 stmt) stmt)

--- a/src/specializer.pl
+++ b/src/specializer.pl
@@ -1,10 +1,17 @@
 :- dynamic ho_specialization/2.
 :- dynamic ho_specialization_failed/3.
 
-%Maybe specializes HV(AVs) if not already ongoing, and if specialization fails, nothing changes and specneeded is restored:
-maybe_specialize_call(HV, AVs, Out, Goal) :- setup_call_cleanup( (catch(nb_getval(specneeded,Prev),_,Prev = []), nb_setval(specneeded,false)),
+%Maybe specializes HV(AVs) if not already ongoing, and if specialization fails, nothing changes and specneeded is restored.
+%Re-specializing a function already being specialized is refused: its key must differ from the ongoing one
+%(same keys are memoized via ho_specialization), and ever-growing keys - e.g. a recursive call wrapping its
+%higher-order argument, (= (evolve $r $g) (evolve (twice $r) $g)) - would otherwise diverge at compile time:
+maybe_specialize_call(HV, AVs, Out, Goal) :- catch(nb_getval('$spec_stack', Stack), _, Stack = []),
+                                             \+ memberchk(HV, Stack),
+                                             setup_call_cleanup( (catch(nb_getval(specneeded,Prev),_,Prev = []), nb_setval(specneeded,false),
+                                                                  nb_setval('$spec_stack', [HV|Stack])),
                                                                  specialize_call(HV, AVs, Out, Goal),
-                                                                 (Prev == true -> nb_setval(specneeded,Prev)) ).
+                                                                 (nb_setval('$spec_stack', Stack),
+                                                                  (Prev == true -> nb_setval(specneeded,Prev) ; true)) ).
 
 % Build a stable, variant-normalized specialization key.
 %

--- a/src/specializer.pl
+++ b/src/specializer.pl
@@ -62,7 +62,7 @@ specialize_call(HV, AVs, Out, Goal) :- %1. Retrieve a copy of all meta-clauses s
                                                  format(atom(Label), "metta specialization (~w)", [SpecName]),
                                                  maybe_print_compiled_clause(Label, Input, Clause) ))
                                                %4.6 Ok specialized, but if we did not succeed ensure the specialization is retracted:
-                                               -> true ; format("Not specialized ~w~n", [SpecName/Arity]),
+                                               -> true ; ( silent(true) -> true ; format("Not specialized ~w~n", [SpecName/Arity]) ),
                                                          forget_symbol(SpecName),
                                                          retractall(ho_specialization(HV, SpecName)),
                                                          ( ho_specialization_failed(HV, Arity, CleanBindSet)


### PR DESCRIPTION
The specializer can diverge at compile time. A recursive call that wraps its
higher-order argument, e.g.

```
(= (derive $g) $g)
(= (twice $r $g) ($r ($r $g)))
(= (evolve $r $n $g) (if (== $n 0) $g (evolve (twice $r) (- $n 1) $g)))
!(evolve derive 2 stmt)
```

never finishes translating: every nested specialization builds a strictly
larger key (`partial(twice,[derive])`, then
`partial(twice,[partial(twice,[derive])])`, ...) so the ho_specialization
memo never hits. No type declarations involved; reproduces on current main.

Fix: a function that is already on the in-progress specialization stack is
not re-specialized. An identical key would have been memoized, so a nested
occurrence necessarily has a different, growing key - exactly the divergence
signature. The inner call just compiles as a normal unspecialized call, and
since the set of function symbols reachable from a clause body is finite,
refusing same-function re-entry guarantees termination. Chains of distinct
functions still specialize as before.

Also gates the "Not specialized" fallback print behind the silent flag like
the other translator diagnostics.

The repro above is included as examples/specialize_recursive_wrap.metta (it
now compiles and returns the right value); test.sh green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hetjCktvza2Xa7nCopnJx
