### PR TITLE
Recover packaged PeTTa CLI as a clean PR

### DIFF
--- a/python/petta/cli.py
+++ b/python/petta/cli.py
@@ -1,0 +1,36 @@
+"""Command-line launcher for the bundled PeTTa runtime."""
+
+import os
+import subprocess
+import sys
+
+from . import _resolve_petta_path
+
+
+def main(argv=None):
+    """Run PeTTa's SWI-Prolog entry point and return its exit status."""
+    if argv is None:
+        argv = sys.argv[1:]
+
+    runtime_root = _resolve_petta_path()
+    main_file = os.path.join(runtime_root, "src", "main.pl")
+    command = [
+        "swipl",
+        "--stack_limit=8g",
+        "-q",
+        "-s",
+        main_file,
+        "--",
+        *argv,
+    ]
+
+    mork_library = os.path.join(
+        runtime_root, "mork_ffi", "target", "release", "libmork_ffi.so"
+    )
+    env = None
+    if os.path.isfile(mork_library):
+        env = os.environ.copy()
+        env["LD_PRELOAD"] = mork_library
+        command.append("mork")
+
+    return subprocess.call(command, env=env)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,53 @@
+import os
+from unittest.mock import Mock
+
+from petta import cli
+
+
+def test_main_forwards_arguments_and_exit_status(monkeypatch, tmp_path):
+    runtime = tmp_path / "runtime with spaces"
+    main_file = runtime / "src" / "main.pl"
+    main_file.parent.mkdir(parents=True)
+    main_file.touch()
+    call = Mock(return_value=23)
+    monkeypatch.setattr(cli, "_resolve_petta_path", lambda: str(runtime))
+    monkeypatch.setattr(cli.subprocess, "call", call)
+
+    status = cli.main(["program with spaces.metta", "--example"])
+
+    assert status == 23
+    call.assert_called_once_with(
+        [
+            "swipl",
+            "--stack_limit=8g",
+            "-q",
+            "-s",
+            str(main_file),
+            "--",
+            "program with spaces.metta",
+            "--example",
+        ],
+        env=None,
+    )
+
+
+def test_main_preserves_optional_mork_behavior(monkeypatch, tmp_path):
+    runtime = tmp_path / "runtime"
+    mork_library = (
+        runtime / "mork_ffi" / "target" / "release" / "libmork_ffi.so"
+    )
+    mork_library.parent.mkdir(parents=True)
+    mork_library.touch()
+    call = Mock(return_value=0)
+    monkeypatch.setattr(cli, "_resolve_petta_path", lambda: str(runtime))
+    monkeypatch.setattr(cli.subprocess, "call", call)
+    monkeypatch.setenv("PETTA_CLI_TEST", "inherited")
+
+    assert cli.main(["program.metta"]) == 0
+
+    command = call.call_args.args[0]
+    child_env = call.call_args.kwargs["env"]
+    assert command[-2:] == ["program.metta", "mork"]
+    assert child_env["LD_PRELOAD"] == str(mork_library)
+    assert child_env["PETTA_CLI_TEST"] == "inherited"
+    assert child_env is not os.environ

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     package_dir={"": "python"},
     include_package_data=True,
     cmdclass={"build_py": build_py_with_runtime},
+    entry_points={"console_scripts": ["petta=petta.cli:main"]},
     install_requires=[
         'janus-swi',
     ],

--- a/tests/test_packaged_cli.sh
+++ b/tests/test_packaged_cli.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+command -v uv >/dev/null
+command -v swipl >/dev/null
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT HUP INT TERM
+
+uv build --wheel --out-dir "$fixture/dist" "$project_dir"
+wheel=$(find "$fixture/dist" -name 'petta-*.whl' -print -quit)
+uv venv "$fixture/venv"
+uv pip install --python "$fixture/venv/bin/python" --no-deps "$wheel"
+test -x "$fixture/venv/bin/petta"
+
+mkdir "$fixture/unrelated cwd"
+printf '!(+ 1 1)\n' > "$fixture/basic.metta"
+printf '!(import! &self (library lib_import))\n' > "$fixture/import.metta"
+printf '!(import! &self (library lib_roman))\n!(map-flat (+ 1) (1 2 3))\n' \
+    > "$fixture/roman.metta"
+
+(
+    cd "$fixture/unrelated cwd"
+    unset PETTA_PATH
+    "$fixture/venv/bin/petta" "$fixture/basic.metta" > "$fixture/basic.log"
+    "$fixture/venv/bin/petta" "$fixture/import.metta" > "$fixture/import.log"
+    "$fixture/venv/bin/petta" "$fixture/roman.metta" > "$fixture/roman.log"
+)
+
+grep -Fxq '2' "$fixture/basic.log"
+grep -Fq '(2 3 4)' "$fixture/roman.log"
+
+echo "packaged petta CLI tests passed"


### PR DESCRIPTION
<!-- myclaw:managed-pr-description:v1 -->

## Summary

Recovered the exact reviewed packaged-CLI patch onto freshly fetched canonical trueagi-io/PeTTa main baseline a595211ae453404e5420feec0f53c57fec830d30. The recovery commit is its direct and sole child; merge-base and parent both equal the baseline. Base..head changes exactly python/petta/cli.py (A), python/tests/test_cli.py (A), setup.py (M), tests/test_packaged_cli.sh (A), totaling 4 files and 124 insertions. Stable patch-id a587e55fe1b0567af9114a650b2227c1127d20e6 exactly matches d2cb59c; no reconciliation was needed. Neither d2cb59c nor fade618 is an ancestor, and originHTTPS/main..HEAD contains only this commit. Focused CLI tests, wheel build/metadata/assets, clean isolated installation, packaged runtime resolution, and controlled SWI invocation/argument/stdin/exit-status behavior passed. The host has no SWI-Prolog, so native normal/lib_import/lib_roman smoke cases and Janus-dependent tests could not run; tests/test_packaged_cli.sh exits at command -v swipl and the full Python suite reports 4 passed plus 3 Janus environment errors. No push or PR creation was performed.

## Why

Task \`task_432159a549704d8b\` (Package the \`petta\` CLI for uv-installed consumers) was integrated locally before PeTTa's GitHub pull-request policy was successfully enabled. Its reviewed implementation content is commit \`d2cb59cf65dd1ba0a08009381384ee4415e65477\` (four files, 124 insertions); the later local integration result \`fade61896c3bd41a94d8f45d9c23a22ff0495716\` is an empty resubmission commit whose parent is d2cb59c. Both currently sit on local branch \`integration/import-overhaul-all\`, which contains several unrelated commits and must not be pushed wholesale. PeTTa is now configured for GitHub PR integration using remote \`originHTTPS\`, canonical repository \`trueagi-io/PeTTa\`, base \`main\`. Create a fresh isolated recovery implementation based on the current remote/canonical \`main\` baseline and reapply only the exact packaged-CLI patch from d2cb59c, preserving its reviewed behavior and tests. Complete it normally so exact source-home review and the broker-owned PR publication path create a clean PR.

## Validation

- PASS: PYTHONPATH=python UV_CACHE_DIR=/tmp/petta-uv-cache UV_TOOL_DIR=/tmp/petta-uv-tools uvx --from pytest pytest python/tests/test_cli.py -q — 2 passed
- PASS: UV_CACHE_DIR=/tmp/petta-uv-cache uv build --wheel --out-dir /tmp/petta-task-a6a46e55490548db/dist . — built petta-0.1.0-py3-none-any.whl
- PASS: wheel inspection — console entry point petta=petta.cli:main; cli.py, _runtime/src/main.pl, _runtime/python/helper.pl, lib_import.pl, and lib_roman.metta present
- PASS: clean uv venv + uv pip install --no-deps of built wheel
- PASS: from unrelated cwd with PETTA_PATH unset, installed console script resolved bundled runtime and controlled SWI verified arguments, inherited stdin, and exit status 23

## Risks

- Native normal MeTTa, lib_import, lib_roman, and Janus-dependent smoke cases remain to be confirmed by SWI-equipped CI because this task host has neither swipl nor janus_swi.

## Assumptions

- Fresh fetch result originHTTPS/main=a595211ae453404e5420feec0f53c57fec830d30 is the canonical baseline.
- Native SWI/Janus checks will run in the repository CI environment that supplies SWI-Prolog.

## MyClaw provenance

- Task: `task_a6a46e55490548db`
- Reviewed commit: `56c01567db481244b8536ca442b344ae3988a4fe`
- Decision fingerprint: `a92148092d8b7f21b7062188c75b92600734092cdf1486d791d911c6bce32ab8`

<!-- /myclaw:managed-pr-description -->