### PR TITLE
Split early import loading semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ python/__pycache__
 python/HE/__pycache__
 python/tests/__pycache__
 python/petta/__pycache__
+__pycache__/
+*.py[cod]
 
 # Python build artifacts
 build/

--- a/examples/import_duplicate_cycle.metta
+++ b/examples/import_duplicate_cycle.metta
@@ -1,0 +1,7 @@
+!(import! &self imports/overhaul/duplicate)
+!(import! &self ./imports/overhaul/./duplicate.metta)
+!(import! &self imports/overhaul/cycle_a)
+
+!(test (collapse (duplicate-import-result)) (loaded-once))
+!(test (cycle-a) a)
+!(test (cycle-b) b)

--- a/examples/import_error_surface.metta
+++ b/examples/import_error_surface.metta
@@ -1,0 +1,11 @@
+!(import! &self ../lib/lib_he)
+
+!(test (if-error (catch (import! &self imports/import_error_broken))
+                 Error
+                 NoError)
+       Error)
+
+!(test (if-error (catch (import! &self imports/definitely_missing_import))
+                 Error
+                 NoError)
+       Error)

--- a/examples/import_relative_nested.metta
+++ b/examples/import_relative_nested.metta
@@ -1,0 +1,4 @@
+!(import! &self imports/relative/root)
+
+!(test (from-sibling) 42)
+!(test (from-second) 7)

--- a/examples/import_space_identity.metta
+++ b/examples/import_space_identity.metta
@@ -1,0 +1,8 @@
+!(bind! &import-space-a (new-space))
+!(bind! &import-space-b (new-space))
+
+!(import! &import-space-a imports/overhaul/space_payload)
+!(import! &import-space-b imports/overhaul/space_payload)
+
+!(test (collapse (match &import-space-a (import-space-marker) present)) (present))
+!(test (collapse (match &import-space-b (import-space-marker) present)) (present))

--- a/examples/imports/import_error_broken.metta
+++ b/examples/imports/import_error_broken.metta
@@ -1,0 +1,1 @@
+(= (broken-import) a

--- a/examples/imports/overhaul/cycle_a.metta
+++ b/examples/imports/overhaul/cycle_a.metta
@@ -1,0 +1,3 @@
+!(import! &self cycle_b)
+
+(= (cycle-a) a)

--- a/examples/imports/overhaul/cycle_b.metta
+++ b/examples/imports/overhaul/cycle_b.metta
@@ -1,0 +1,3 @@
+!(import! &self ./cycle_a.metta)
+
+(= (cycle-b) b)

--- a/examples/imports/overhaul/duplicate.metta
+++ b/examples/imports/overhaul/duplicate.metta
@@ -1,0 +1,1 @@
+(= (duplicate-import-result) loaded-once)

--- a/examples/imports/overhaul/space_payload.metta
+++ b/examples/imports/overhaul/space_payload.metta
@@ -1,0 +1,1 @@
+(import-space-marker)

--- a/examples/imports/relative/root.metta
+++ b/examples/imports/relative/root.metta
@@ -1,0 +1,2 @@
+!(import! &self subdir/parent)
+!(import! &self second)

--- a/examples/imports/relative/second.metta
+++ b/examples/imports/relative/second.metta
@@ -1,0 +1,1 @@
+(= (from-second) 7)

--- a/examples/imports/relative/subdir/parent.metta
+++ b/examples/imports/relative/subdir/parent.metta
@@ -1,0 +1,2 @@
+!(import! &self sibling)
+!(import! &self python_helper.py)

--- a/examples/imports/relative/subdir/python_helper.py
+++ b/examples/imports/relative/subdir/python_helper.py
@@ -1,0 +1,1 @@
+"""Fixture proving Python imports resolve from the importing MeTTa file."""

--- a/examples/imports/relative/subdir/sibling.metta
+++ b/examples/imports/relative/subdir/sibling.metta
@@ -1,0 +1,1 @@
+(= (from-sibling) 42)

--- a/examples/test_unify_eval_branches.metta
+++ b/examples/test_unify_eval_branches.metta
@@ -6,7 +6,7 @@
 ;; Without the eval fix (lib_he.metta lines 24-25), space-based unify
 ;; returns unevaluated expressions such as (+ 1 2) instead of 3.
 
-!(import! &self lib/lib_he)
+!(import! &self ../lib/lib_he)
 
 ;; --- Knowledge base atoms (like pverify's Constant/Var declarations) ---
 (Constant wff (Type "$c"))

--- a/lib/lib_import.pl
+++ b/lib/lib_import.pl
@@ -84,13 +84,16 @@ replace_all(P, R, S, O) :- split_string(S, P, "", Parts),
 'git-import!'(GitPath, BuildCmd, true) :- 'git-import!'(GitPath, BuildCmd, './repos', true).
      
 'git-import!'(GitPath, BuildCmd, BaseDir, true) :- ( exists_directory(BaseDir) -> true
-                                                                                 ; format("What ~w~n", [BaseDir]), make_directory_path(BaseDir) ),
+                                                                                 ; make_directory_path(BaseDir) ),
                                                    repo_name_from_git(GitPath, Name),
                                                    directory_file_path(BaseDir, Name, LocalDir),
                                                    ( exists_directory(LocalDir) -> true
                                                                                  ; clone_repo(GitPath, LocalDir),
                                                                                    run_build_step(LocalDir, BuildCmd) ),
-                                                   asserta(library_path(LocalDir)).
+                                                   register_git_library_path(LocalDir).
+
+register_git_library_path(LocalDir) :- absolute_file_name(LocalDir, CanonDir, [file_type(directory), file_errors(fail)]),
+                                       ( library_path(CanonDir) -> true ; asserta(library_path(CanonDir)) ).
 
 % Reproducible import: URL, build command, base directory, full commit SHA.
 'git-import!'(GitPath, BuildCmd, BaseDir, CommitSHA, true) :-
@@ -259,19 +262,21 @@ repo_name_from_git(GitPath, Name) :- atom_string(GitPath, S),
                                      atom_string(Name, Last).
 
 clone_repo(GitPath, LocalDir) :- format("Cloning ~w into ~w~n", [GitPath, LocalDir]),
-                                 process_create(path(git),
-                                                ['clone', '--depth', '1', GitPath, LocalDir],
-                                                [stdout(pipe(Out)), stderr(pipe(Err))]),
-                                 read_string(Out, _, _),
-                                 read_string(Err, _, _),
-                                 close(Out), close(Err).
+                                 run_git_import_process(path(git),
+                                                        ['clone', '--depth', '1', GitPath, LocalDir],
+                                                        [],
+                                                        clone(GitPath)).
 
 run_build_step(_, BuildCmd) :- (BuildCmd = '' ; BuildCmd = ""), !.
 run_build_step(LocalDir, BuildCmd) :- format("Running build: ~w in ~w~n", [BuildCmd, LocalDir]),
-                                      process_create(path(sh),
-                                                     [BuildCmd],
-                                                     [cwd(LocalDir),
-                                                      stdout(pipe(Out)), stderr(pipe(Err))]),
-                                      read_string(Out, _, _),
-                                      read_string(Err, _, _),
-                                      close(Out), close(Err).
+                                      run_git_import_process(path(sh),
+                                                             [BuildCmd],
+                                                             [cwd(LocalDir)],
+                                                             build(BuildCmd)).
+
+run_git_import_process(Executable, Args, Options, Operation) :-
+    process_create(Executable, Args, [process(PID)|Options]),
+    process_wait(PID, Status),
+    ( Status = exit(0)
+      -> true
+       ; throw(error(process_error(Operation, Status), context('git-import!', Operation))) ).

--- a/lib/lib_import.pl
+++ b/lib/lib_import.pl
@@ -90,10 +90,10 @@ replace_all(P, R, S, O) :- split_string(S, P, "", Parts),
                                                    ( exists_directory(LocalDir) -> true
                                                                                  ; clone_repo(GitPath, LocalDir),
                                                                                    run_build_step(LocalDir, BuildCmd) ),
-                                                   register_git_library_path(LocalDir).
+                                                   register_library_path(LocalDir).
 
-register_git_library_path(LocalDir) :- absolute_file_name(LocalDir, CanonDir, [file_type(directory), file_errors(fail)]),
-                                       ( library_path(CanonDir) -> true ; asserta(library_path(CanonDir)) ).
+register_library_path(Path0) :- absolute_file_name(Path0, Path, [file_type(directory), file_errors(fail)]),
+                                ( library_path(Path) -> true ; asserta(library_path(Path)) ).
 
 % Reproducible import: URL, build command, base directory, full commit SHA.
 'git-import!'(GitPath, BuildCmd, BaseDir, CommitSHA, true) :-
@@ -105,7 +105,7 @@ register_git_library_path(LocalDir) :- absolute_file_name(LocalDir, CanonDir, [f
     setup_call_cleanup(open(LockFile, append, Lock, [lock(write)]),
                        pinned_import_locked(GitPath, BuildCmd, BaseDir, Name, LocalDir, Commit),
                        close(Lock)),
-    asserta(library_path(LocalDir)).
+    register_library_path(LocalDir).
 
 validate_commit_sha(CommitSHA, Commit) :-
     atom_string(CommitSHA, CommitString),

--- a/python/helper.pl
+++ b/python/helper.pl
@@ -1,11 +1,6 @@
 maybe_enable_silent(true) :- !.
 maybe_enable_silent(false) :- assertz(silent(true)).
 
-set_working_dir(load_metta_file, File) :-
-    file_directory_name(File, Dir),
-    retractall(working_dir(_)),
-    assertz(working_dir(Dir)),
-    !.
 set_working_dir(_, _).
 
 run_metta_helper(Verbose, Predicate, Arg, ResultsR) :-

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -1,0 +1,24 @@
+import uuid
+
+import pytest
+
+
+def test_failed_import_can_be_retried(petta_instance, tmp_path):
+    module_name = f"petta_retry_{uuid.uuid4().hex}"
+    root_file = tmp_path / "root.metta"
+    dependency_file = tmp_path / "dependency.metta"
+    python_file = tmp_path / f"{module_name}.py"
+
+    root_file.write_text("!(import! &self dependency)\n!(retry-result)\n")
+    dependency_file.write_text(
+        f'!(import! &self "{module_name}.py")\n(= (retry-result) retry-ok)\n'
+    )
+    python_file.write_text('raise RuntimeError("first import fails")\n')
+
+    with pytest.raises(Exception, match="first import fails"):
+        petta_instance.load_metta_file(str(root_file))
+
+    python_file.write_text("RETRY_SUCCEEDED = True\n")
+    results = petta_instance.load_metta_file(str(root_file))
+
+    assert "retry-ok" in results

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -22,3 +22,25 @@ def test_failed_import_can_be_retried(petta_instance, tmp_path):
     results = petta_instance.load_metta_file(str(root_file))
 
     assert "retry-ok" in results
+
+
+def test_import_after_use_warns(petta_instance, tmp_path, capfd):
+    fn = f"late_inc_{uuid.uuid4().hex}"
+    root_file = tmp_path / "root.metta"
+    dependency_file = tmp_path / "dependency.metta"
+
+    dependency_file.write_text(f"(= ({fn} $x) (+ $x 1))\n")
+    root_file.write_text(
+        f"(= (uses-{fn} $x) ({fn} $x))\n"
+        "!(import! &self dependency)\n"
+        f"!(uses-{fn} 41)\n"
+    )
+
+    results = petta_instance.load_metta_file(str(root_file))
+    stderr = capfd.readouterr().err
+
+    # The definition compiled before the import treats the name as a plain symbol...
+    assert f"({fn} 41)" in results
+    # ...and the late registration is called out.
+    assert fn in stderr
+    assert "Move the import or definition above the first use" in stderr

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -3,25 +3,57 @@ import uuid
 import pytest
 
 
-def test_failed_import_can_be_retried(petta_instance, tmp_path):
-    module_name = f"petta_retry_{uuid.uuid4().hex}"
-    root_file = tmp_path / "root.metta"
-    dependency_file = tmp_path / "dependency.metta"
-    python_file = tmp_path / f"{module_name}.py"
+def test_direct_entry_file_cycle_loads_once(petta_instance, tmp_path):
+    suffix = uuid.uuid4().hex
+    cycle_a = tmp_path / "cycle_a.metta"
+    cycle_b = tmp_path / "cycle_b.metta"
 
-    root_file.write_text("!(import! &self dependency)\n!(retry-result)\n")
-    dependency_file.write_text(
-        f'!(import! &self "{module_name}.py")\n(= (retry-result) retry-ok)\n'
+    cycle_a.write_text(
+        f"!(import! &self cycle_b)\n(= (cycle-a-{suffix}) cycle-a-result)\n"
+        f"!(cycle-a-{suffix})\n"
     )
-    python_file.write_text('raise RuntimeError("first import fails")\n')
+    cycle_b.write_text(
+        f"!(import! &self cycle_a)\n(= (cycle-b-{suffix}) cycle-b-result)\n"
+    )
 
-    with pytest.raises(Exception, match="first import fails"):
-        petta_instance.load_metta_file(str(root_file))
+    results = petta_instance.load_metta_file(str(cycle_a))
 
-    python_file.write_text("RETRY_SUCCEEDED = True\n")
+    assert results.count("cycle-a-result") == 1
+
+
+def test_source_functions_compile_once_across_spaces(petta_instance, tmp_path):
+    suffix = uuid.uuid4().hex
+    dependency_file = tmp_path / "dependency.metta"
+    root_file = tmp_path / "root.metta"
+
+    dependency_file.write_text(f"(= (shared-{suffix}) shared-result)\n")
+    root_file.write_text(
+        "!(bind! &space-a (new-space))\n"
+        "!(bind! &space-b (new-space))\n"
+        "!(import! &space-a dependency)\n"
+        "!(import! &space-b dependency)\n"
+        f"!(shared-{suffix})\n"
+    )
+
     results = petta_instance.load_metta_file(str(root_file))
 
-    assert "retry-ok" in results
+    assert results.count("shared-result") == 1
+
+
+def test_nested_import_does_not_fall_back_to_cwd(
+    petta_instance, tmp_path, monkeypatch
+):
+    importer_dir = tmp_path / "importer"
+    cwd_dir = tmp_path / "cwd"
+    importer_dir.mkdir()
+    cwd_dir.mkdir()
+    root_file = importer_dir / "root.metta"
+    root_file.write_text("!(import! &self dependency)\n")
+    (cwd_dir / "dependency.metta").write_text("(cwd-only-dependency)\n")
+    monkeypatch.chdir(cwd_dir)
+
+    with pytest.raises(Exception, match="source_sink"):
+        petta_instance.load_metta_file(str(root_file))
 
 
 def test_import_after_use_warns(petta_instance, tmp_path, capfd):

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -40,6 +40,44 @@ def test_source_functions_compile_once_across_spaces(petta_instance, tmp_path):
     assert results.count("shared-result") == 1
 
 
+def test_cross_space_cycle_compiles_source_functions_once(
+    petta_instance, tmp_path
+):
+    suffix = uuid.uuid4().hex
+    space_a = f"&space-a-{suffix}"
+    space_b = f"&space-b-{suffix}"
+    root_file = tmp_path / "root.metta"
+    a_file = tmp_path / "a.metta"
+    b_file = tmp_path / "b.metta"
+
+    root_file.write_text(
+        f"!(bind! {space_a} (new-space))\n"
+        f"!(bind! {space_b} (new-space))\n"
+        f"!(import! {space_a} a)\n"
+        f"!(shared-result-{suffix})\n"
+    )
+    a_file.write_text(
+        f"!(import! {space_b} b)\n"
+        f"(= (shared-result-{suffix}) result)\n"
+    )
+    b_file.write_text(f"!(import! {space_b} a)\n")
+
+    results = petta_instance.load_metta_file(str(root_file))
+
+    assert results.count("result") == 1
+
+
+def test_python_import_failure_is_propagated(petta_instance, tmp_path):
+    module_name = f"petta_failure_{uuid.uuid4().hex}"
+    root_file = tmp_path / "root.metta"
+    python_file = tmp_path / f"{module_name}.py"
+    root_file.write_text(f'!(import! &self "{module_name}.py")\n')
+    python_file.write_text('raise RuntimeError("python import failed")\n')
+
+    with pytest.raises(Exception, match="python import failed"):
+        petta_instance.load_metta_file(str(root_file))
+
+
 def test_nested_import_does_not_fall_back_to_cwd(
     petta_instance, tmp_path, monkeypatch
 ):

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -2,11 +2,23 @@
 :- use_module(library(pcre)). % re_replace/4
 :- current_prolog_flag(argv, Args), ( (memberchk(silent, Args) ; memberchk('--silent', Args) ; memberchk('-s', Args))
                                       -> assertz(silent(true)) ; assertz(silent(false)) ).
+:- dynamic working_dir/1.
+
+push_working_dir(Filename) :- file_directory_name(Filename, Dir0),
+                              ( absolute_file_name(Dir0, Dir, [file_type(directory), file_errors(fail)])
+                                -> true
+                                 ; Dir = Dir0 ),
+                              asserta(working_dir(Dir)).
+
+pop_working_dir :- retract(working_dir(_)), !.
+pop_working_dir.
 
 %Read Filename into string S and process it (S holds MeTTa code):
 load_metta_file(Filename, Results) :- load_metta_file(Filename, Results, '&self').
-load_metta_file(Filename, Results, Space) :- read_file_to_string(Filename, S, []),
-                                             process_metta_string(S, Results, Space).
+load_metta_file(Filename, Results, Space) :- setup_call_cleanup(push_working_dir(Filename),
+                                                                ( read_file_to_string(Filename, S, []),
+                                                                  process_metta_string(S, Results, Space) ),
+                                                                pop_working_dir).
 
 %Extract function definitions, call invocations, and S-expressions part of &self space:
 process_metta_string(S, Results) :- process_metta_string(S, Results, '&self').

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -39,9 +39,22 @@ process_metta_string(S, Results, Space) :- string_codes(S, Cs),
                                            maplist(process_form(Space), ParsedForms, ResultsList), !,
                                            append(ResultsList, Results).
 
+register_function_signature(F, Arity) :- warn_if_used_as_symbol(F),
+                                         register_fun(F),
+                                         ( catch(arity(F, Arity), _, fail) -> true ; assertz(arity(F, Arity)) ).
+
+%A function arriving after expressions already compiled its name as a plain symbol
+%cannot be called by those expressions anymore, which usually means an import came too late:
+warn_if_used_as_symbol(F) :- \+ fun(F), symbol_head(F), !,
+                             format(user_error, "Warning: ~w is defined or imported after already being used; earlier expressions treat it as a plain symbol. Move the import or definition above the first use.~n", [F]).
+warn_if_used_as_symbol(_).
+
 %First pass to convert MeTTa to Prolog Terms and register functions:
 parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
-                                           ( Term = [=, [F|W], _], atom(F) -> register_fun(F), length(W, N), Arity is N + 1, assertz(arity(F,Arity)), T=function
+                                           ( Term = [=, [F|W], _], atom(F) -> length(W, N),
+                                                                              Arity is N + 1,
+                                                                              register_function_signature(F, Arity),
+                                                                              T=function
                                                                             ; T=expression ).
 parse_form(runnable(S), parsed(runnable, S, Term)) :- sread(S, Term).
 

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -15,10 +15,20 @@ pop_working_dir.
 
 %Read Filename into string S and process it (S holds MeTTa code):
 load_metta_file(Filename, Results) :- load_metta_file(Filename, Results, '&self').
-load_metta_file(Filename, Results, Space) :- setup_call_cleanup(push_working_dir(Filename),
-                                                                ( read_file_to_string(Filename, S, []),
-                                                                  process_metta_string(S, Results, Space) ),
-                                                                pop_working_dir).
+load_metta_file(Filename, Results, Space) :- catch(load_metta_file_impl(Filename, Results, Space),
+                                                   Error,
+                                                   rethrow_metta_file_error(Filename, Error)).
+
+load_metta_file_impl(Filename, Results, Space) :- setup_call_cleanup(push_working_dir(Filename),
+                                                                     ( read_file_to_string(Filename, S, []),
+                                                                       process_metta_string(S, Results, Space) ),
+                                                                     pop_working_dir).
+
+rethrow_metta_file_error(_, Error) :- Error = error(_, context(_, _)), !,
+                                      throw(Error).
+rethrow_metta_file_error(Filename, error(Type, _)) :- !,
+                                                      throw(error(Type, context(Filename, 'while loading MeTTa file'))).
+rethrow_metta_file_error(_, Error) :- throw(Error).
 
 %Extract function definitions, call invocations, and S-expressions part of &self space:
 process_metta_string(S, Results) :- process_metta_string(S, Results, '&self').

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -4,7 +4,7 @@
                                       -> assertz(silent(true)) ; assertz(silent(false)) ).
 :- dynamic working_dir/1.
 :- dynamic active_metta_load/2.
-:- dynamic metta_source_functions_compiled/1.
+:- dynamic metta_source_functions_started/1.
 
 push_working_dir(Filename) :- file_directory_name(Filename, Dir0),
                               ( absolute_file_name(Dir0, Dir, [file_type(directory), file_errors(fail)])
@@ -30,18 +30,18 @@ load_metta_file_impl(Filename, Results, Space) :-
     ).
 
 load_metta_file_contents(CanonPath, Results, Space) :-
-    ( metta_source_functions_compiled(CanonPath)
-      -> Mode = space_only
-       ; Mode = compile_functions ),
+    claim_source_compile(CanonPath, Mode),
     setup_call_cleanup(
         push_working_dir(CanonPath),
         ( read_file_to_string(CanonPath, S, []),
-          process_metta_string(S, Results, Space, Mode),
-          ( Mode = compile_functions
-            -> assertz(metta_source_functions_compiled(CanonPath))
-             ; true ) ),
+          process_metta_string(S, Results, Space, Mode) ),
         pop_working_dir
     ).
+
+claim_source_compile(CanonPath, space_only) :-
+    metta_source_functions_started(CanonPath), !.
+claim_source_compile(CanonPath, compile_functions) :-
+    assertz(metta_source_functions_started(CanonPath)).
 
 rethrow_metta_file_error(_, Error) :- Error = error(_, context(_, _)), !,
                                       throw(Error).

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -3,6 +3,8 @@
 :- current_prolog_flag(argv, Args), ( (memberchk(silent, Args) ; memberchk('--silent', Args) ; memberchk('-s', Args))
                                       -> assertz(silent(true)) ; assertz(silent(false)) ).
 :- dynamic working_dir/1.
+:- dynamic active_metta_load/2.
+:- dynamic metta_source_functions_compiled/1.
 
 push_working_dir(Filename) :- file_directory_name(Filename, Dir0),
                               ( absolute_file_name(Dir0, Dir, [file_type(directory), file_errors(fail)])
@@ -19,10 +21,27 @@ load_metta_file(Filename, Results, Space) :- catch(load_metta_file_impl(Filename
                                                    Error,
                                                    rethrow_metta_file_error(Filename, Error)).
 
-load_metta_file_impl(Filename, Results, Space) :- setup_call_cleanup(push_working_dir(Filename),
-                                                                     ( read_file_to_string(Filename, S, []),
-                                                                       process_metta_string(S, Results, Space) ),
-                                                                     pop_working_dir).
+load_metta_file_impl(Filename, Results, Space) :-
+    absolute_file_name(Filename, CanonPath, [access(read), file_errors(fail)]),
+    setup_call_cleanup(
+        assertz(active_metta_load(Space, CanonPath), Ref),
+        load_metta_file_contents(CanonPath, Results, Space),
+        erase(Ref)
+    ).
+
+load_metta_file_contents(CanonPath, Results, Space) :-
+    ( metta_source_functions_compiled(CanonPath)
+      -> Mode = space_only
+       ; Mode = compile_functions ),
+    setup_call_cleanup(
+        push_working_dir(CanonPath),
+        ( read_file_to_string(CanonPath, S, []),
+          process_metta_string(S, Results, Space, Mode),
+          ( Mode = compile_functions
+            -> assertz(metta_source_functions_compiled(CanonPath))
+             ; true ) ),
+        pop_working_dir
+    ).
 
 rethrow_metta_file_error(_, Error) :- Error = error(_, context(_, _)), !,
                                       throw(Error).
@@ -32,12 +51,14 @@ rethrow_metta_file_error(_, Error) :- throw(Error).
 
 %Extract function definitions, call invocations, and S-expressions part of &self space:
 process_metta_string(S, Results) :- process_metta_string(S, Results, '&self').
-process_metta_string(S, Results, Space) :- string_codes(S, Cs),
-                                           strip(Cs, 0, Codes),
-                                           phrase(top_forms(Forms, 1), Codes),
-                                           maplist(parse_form, Forms, ParsedForms),
-                                           maplist(process_form(Space), ParsedForms, ResultsList), !,
-                                           append(ResultsList, Results).
+process_metta_string(S, Results, Space) :-
+    process_metta_string(S, Results, Space, compile_functions).
+process_metta_string(S, Results, Space, Mode) :- string_codes(S, Cs),
+                                                 strip(Cs, 0, Codes),
+                                                 phrase(top_forms(Forms, 1), Codes),
+                                                 maplist(parse_form, Forms, ParsedForms),
+                                                 maplist(process_form(Space, Mode), ParsedForms, ResultsList), !,
+                                                 append(ResultsList, Results).
 
 register_function_signature(F, Arity) :- warn_if_used_as_symbol(F),
                                          register_fun(F),
@@ -59,16 +80,17 @@ parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
 parse_form(runnable(S), parsed(runnable, S, Term)) :- sread(S, Term).
 
 %Second pass to compile / run / add the Terms:
-process_form(Space, parsed(expression, _, Term), []) :- 'add-atom'(Space, Term, true),
+process_form(Space, _, parsed(expression, _, Term), []) :- 'add-atom'(Space, Term, true),
                                                         ( silent(true) -> true ; swrite(Term,STerm),
                                                                                  format("\e[33m--> metta sexpr -->~n\e[36m~w~n", [STerm]),
                                                                                  format("\e[33m^^^^^^^^^^^^^^^^^^^~n\e[0m") ).
-process_form(_, parsed(runnable, FormStr, Term), Result) :- translate_expr([collapse, Term], Goals, Result),
+process_form(_, _, parsed(runnable, FormStr, Term), Result) :- translate_expr([collapse, Term], Goals, Result),
                                                             ( silent(true) -> true ; format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
                                                                                      forall(member(G, Goals), portray_clause((:- G))),
                                                                                      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m") ),
                                                             call_goals(Goals).
-process_form(Space, parsed(function, FormStr, Term), []) :- add_sexp(Space, Term),
+process_form(Space, space_only, parsed(function, _, Term), []) :- add_sexp(Space, Term).
+process_form(Space, compile_functions, parsed(function, FormStr, Term), []) :- add_sexp(Space, Term),
                                                             Term = [=, [F|_], _],
                                                             translate_clause(Term, Clause),
                                                             assertz(Clause, Ref),
@@ -79,7 +101,7 @@ process_form(Space, parsed(function, FormStr, Term), []) :- add_sexp(Space, Term
                                                                                      ( Body == true -> Show = Head; Show = (Head :- Body) ),
                                                                                      portray_clause(current_output, Show),
                                                                                      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^~n\e[0m") ).
-process_form(_, In, _) :- format(atom(Msg), "failed to process form: ~w", [In]), throw(error(syntax_error(Msg), none)).
+process_form(_, _, In, _) :- format(atom(Msg), "failed to process form: ~w", [In]), throw(error(syntax_error(Msg), none)).
 
 %Like blanks but counts newlines:
 newlines(C0, C2) --> blanks_to_nl, !, {C1 is C0+1}, newlines(C1,C2).

--- a/src/main.pl
+++ b/src/main.pl
@@ -25,9 +25,7 @@ main :- current_prolog_flag(argv, RawArgs),
         ( Args = [] -> prolog_interop_example
         ; Args = [mork] -> prolog_interop_example,
                            mork_test
-        ; Args = [File|_] -> file_directory_name(File, Dir),
-                             assertz(working_dir(Dir)),
-                             load_metta_file(File,Results),
+        ; Args = [File|_] -> load_metta_file(File,Results),
                              maplist(swrite,Results,ResultsR),
                              maplist(format("~w~n"), ResultsR)
         ),

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -301,9 +301,12 @@ retractPredicate(_, false).
 ensure_metta_ext(Path, Path) :- file_name_extension(_, metta, Path), !.
 ensure_metta_ext(Path, PathWithExt) :- file_name_extension(Path, metta, PathWithExt).
 
+current_working_dir(Base) :- working_dir(Base), !.
+current_working_dir(Base) :- absolute_file_name('.', Base, [file_type(directory)]).
+
 'import!'(Space, File, true) :- catch(importer_helper(Space, File), _, fail).
 importer_helper(Space, File) :- atom_string(File, SFile),
-                                working_dir(Base),
+                                current_working_dir(Base),
                                 ( file_name_extension(ModPath, 'py', SFile)
                                   -> absolute_file_name(SFile, Path, [relative_to(Base)]),
                                      file_directory_name(Path, Dir),

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -330,9 +330,6 @@ python_import_file(File) :- import_file_string(File, SFile),
 resolve_existing_import_path(Base, RequestedPath, CanonPath) :-
     absolute_file_name(RequestedPath, CanonPath,
                        [relative_to(Base), access(read), file_errors(fail)]), !.
-resolve_existing_import_path(_, RequestedPath, CanonPath) :-
-    absolute_file_name(RequestedPath, CanonPath,
-                       [access(read), file_errors(fail)]), !.
 
 throw_missing_import(File) :-
     throw(error(existence_error(source_sink, File), context('import!', File))).
@@ -356,10 +353,12 @@ resolve_python_import_path(File, CanonPath) :-
 
 :- dynamic metta_import_state/3.
 
-% A loading entry breaks cycles; a loaded entry makes later imports no-ops.
-% Failed loads remove their entry so callers can repair the source and retry.
+% A loading or active entry breaks cycles; a loaded entry makes later imports no-ops.
+% Failed loads remove their loading entry, but may leave partial state; retrying a
+% failed import in the same runtime is unsupported.
 claim_import(Space, CanonPath, skip) :- metta_import_state(Space, CanonPath, loaded), !.
 claim_import(Space, CanonPath, skip) :- metta_import_state(Space, CanonPath, loading), !.
+claim_import(Space, CanonPath, skip) :- active_metta_load(Space, CanonPath), !.
 claim_import(Space, CanonPath, load) :- assertz(metta_import_state(Space, CanonPath, loading)).
 
 clear_import_state(Space, CanonPath) :- retractall(metta_import_state(Space, CanonPath, _)).

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -1,6 +1,21 @@
 %%%%%%%%%% Dependencies %%%%%%%%%%
-library(X, Path) :- standard_library_path(Base), atomic_list_concat([Base, '/', X], Path).
-library(X, Y, Path) :- library_path(Base), atom_concat(_, X, Base), atomic_list_concat([Base, '/', Y], Path).
+library(X, Path) :- resolve_library_path(library_path_candidate(X), Path).
+library(X, Y, Path) :- resolve_library_path(library_path_candidate(X, Y), Path).
+
+library_path_candidate(X, Path) :- standard_library_path(Base),
+                                   atomic_list_concat([Base, '/', X], Path).
+library_path_candidate(X, Y, Path) :- library_path(Base),
+                                      atom_concat(_, X, Base),
+                                      atomic_list_concat([Base, '/', Y], Path).
+
+resolve_library_path(Candidate, Path) :- ( once((call(Candidate, ExistingPath),
+                                                  library_source_exists(ExistingPath)))
+                                           -> Path = ExistingPath
+                                            ; once(call(Candidate, Path)) ).
+
+library_source_exists(Path) :- exists_file(Path), !.
+library_source_exists(Path) :- file_name_extension(Path, metta, MettaPath),
+                               exists_file(MettaPath).
 :- prolog_load_context(directory, Source),
    directory_file_path(Source, '..', Parent),
    directory_file_path(Parent, 'lib', LibPath),
@@ -304,19 +319,50 @@ ensure_metta_ext(Path, PathWithExt) :- file_name_extension(Path, metta, PathWith
 current_working_dir(Base) :- working_dir(Base), !.
 current_working_dir(Base) :- absolute_file_name('.', Base, [file_type(directory)]).
 
-'import!'(Space, File, true) :- catch(importer_helper(Space, File), _, fail).
-importer_helper(Space, File) :- atom_string(File, SFile),
-                                current_working_dir(Base),
-                                ( file_name_extension(ModPath, 'py', SFile)
-                                  -> absolute_file_name(SFile, Path, [relative_to(Base)]),
-                                     file_directory_name(Path, Dir),
-                                     file_base_name(ModPath, ModuleName),
-                                     py_call(sys:path:append(Dir), _),
-                                     py_call(builtins:'__import__'(ModuleName), _)
-                                   ; ( Path = SFile ; atomic_list_concat([Base, '/', SFile], Path) ),
-                                     ensure_metta_ext(Path, PathWithExt),
-                                     exists_file(PathWithExt), !,
-                                     load_metta_file(PathWithExt, _, Space) ).
+import_file_string(File, SFile) :- string(File), !, SFile = File.
+import_file_string(File, SFile) :- atom_string(File, SFile).
+
+python_import_file(File) :- import_file_string(File, SFile),
+                            file_name_extension(_, py, SFile).
+
+resolve_existing_import_path(Base, RequestedPath, CanonPath) :-
+    absolute_file_name(RequestedPath, CanonPath,
+                       [relative_to(Base), access(read), file_errors(fail)]), !.
+resolve_existing_import_path(_, RequestedPath, CanonPath) :-
+    absolute_file_name(RequestedPath, CanonPath,
+                       [access(read), file_errors(fail)]), !.
+
+throw_missing_import(File) :-
+    throw(error(existence_error(source_sink, File), context('import!', File))).
+
+resolve_metta_import_path(File, CanonPath) :-
+    import_file_string(File, SFile),
+    \+ python_import_file(SFile),
+    current_working_dir(Base),
+    ensure_metta_ext(SFile, RequestedPath),
+    ( resolve_existing_import_path(Base, RequestedPath, CanonPath)
+      -> true
+       ; throw_missing_import(File) ).
+
+resolve_python_import_path(File, CanonPath) :-
+    import_file_string(File, SFile),
+    python_import_file(SFile),
+    current_working_dir(Base),
+    ( resolve_existing_import_path(Base, SFile, CanonPath)
+      -> true
+       ; throw_missing_import(File) ).
+
+'import!'(Space, File, true) :- importer_helper(Space, File).
+importer_helper(Space, File) :-
+    ( python_import_file(File)
+      -> resolve_python_import_path(File, CanonPath),
+         file_directory_name(CanonPath, Dir),
+         file_base_name(CanonPath, BaseName),
+         file_name_extension(ModuleName, _, BaseName),
+         py_call(sys:path:append(Dir), _),
+         py_call(builtins:'__import__'(ModuleName), _)
+       ; resolve_metta_import_path(File, CanonPath),
+         load_metta_file(CanonPath, _, Space) ).
 
 :- dynamic translator_rule/1.
 'add-translator-rule!'(HV, true) :- ( translator_rule(HV)

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -352,6 +352,30 @@ resolve_python_import_path(File, CanonPath) :-
       -> true
        ; throw_missing_import(File) ).
 
+:- dynamic metta_import_state/3.
+
+% A loading entry breaks cycles; a loaded entry makes later imports no-ops.
+% Failed loads remove their entry so callers can repair the source and retry.
+claim_import(Space, CanonPath, skip) :- metta_import_state(Space, CanonPath, loaded), !.
+claim_import(Space, CanonPath, skip) :- metta_import_state(Space, CanonPath, loading), !.
+claim_import(Space, CanonPath, load) :- assertz(metta_import_state(Space, CanonPath, loading)).
+
+clear_import_state(Space, CanonPath) :- retractall(metta_import_state(Space, CanonPath, _)).
+
+mark_import_loaded(Space, CanonPath) :- clear_import_state(Space, CanonPath),
+                                        assertz(metta_import_state(Space, CanonPath, loaded)).
+
+run_new_import(Space, CanonPath, Goal) :-
+    catch(( once(Goal)
+            -> mark_import_loaded(Space, CanonPath)
+             ; clear_import_state(Space, CanonPath), fail ),
+          Error,
+          ( clear_import_state(Space, CanonPath), throw(Error) )).
+
+import_once(Space, CanonPath, Goal) :- claim_import(Space, CanonPath, Action),
+                                       ( Action = skip -> true
+                                                       ; run_new_import(Space, CanonPath, Goal) ).
+
 'import!'(Space, File, true) :- importer_helper(Space, File).
 importer_helper(Space, File) :-
     ( python_import_file(File)
@@ -359,10 +383,11 @@ importer_helper(Space, File) :-
          file_directory_name(CanonPath, Dir),
          file_base_name(CanonPath, BaseName),
          file_name_extension(ModuleName, _, BaseName),
-         py_call(sys:path:append(Dir), _),
-         py_call(builtins:'__import__'(ModuleName), _)
+         import_once(Space, CanonPath,
+                     ( py_call(sys:path:append(Dir), _),
+                       py_call(builtins:'__import__'(ModuleName), _) ))
        ; resolve_metta_import_path(File, CanonPath),
-         load_metta_file(CanonPath, _, Space) ).
+         import_once(Space, CanonPath, load_metta_file(CanonPath, _, Space)) ).
 
 :- dynamic translator_rule/1.
 'add-translator-rule!'(HV, true) :- ( translator_rule(HV)

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -1,4 +1,6 @@
 %%%%%%%%%% Dependencies %%%%%%%%%%
+:- dynamic library_path/1.
+
 library(X, Path) :- resolve_library_path(library_path_candidate(X), Path).
 library(X, Y, Path) :- resolve_library_path(library_path_candidate(X, Y), Path).
 

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -39,6 +39,11 @@ translate_clause(Input, (Head :- BodyConj), ConstrainArgs) :-
                                                append(GoalsPrefix, FinalGoals, Goals),
                                                goals_list_to_conj(Goals, BodyConj).
 
+%Record atoms compiled as plain symbol heads, so late function registrations can be flagged:
+:- dynamic symbol_head/1.
+note_symbol_head(HV) :- atom(HV), \+ symbol_head(HV), !, assertz(symbol_head(HV)).
+note_symbol_head(_).
+
 %Print compiled clause:
 maybe_print_compiled_clause(_, _, _) :- silent(true), !.
 maybe_print_compiled_clause(Label, FormTerm, Clause) :-
@@ -350,7 +355,8 @@ translate_expr([H0|T0], Goals, Out) :-
                          Goals = [Disj] )
               ; build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
           %Literals (numbers, strings, etc.), known non-function atom => data:
-          ; ( atomic(HV), \+ atom(HV) ; atom(HV), \+ fun(HV) ) -> Out = [HV|AVs],
+          ; ( atomic(HV), \+ atom(HV) ; atom(HV), \+ fun(HV) ) -> note_symbol_head(HV),
+                                                                  Out = [HV|AVs],
                                                                   Goals = Inner
           %Plain data list: evaluate inner fun-sublists
           ; is_list(HV) -> eval_data_term(HV, Gd, HV1),


### PR DESCRIPTION
## Summary

This draft splits the first coherent import-loading changes from #203 into an independent review based on current `main`.

It replays exactly these original commits, in order:

1. `0a0e4d0` — Resolve relative imports from the importing file
2. `237a090` — Surface MeTTa import errors
3. `3294517` — Make imports idempotent and cycle-safe
4. `aba3433` — Surface git import failures
5. `3f43640` — Warn when a function arrives after being compiled as a symbol

## Behavior

- Resolve nested relative MeTTa and Python imports from the importing file.
- Propagate missing, malformed, Python, and git import failures instead of silently swallowing them.
- Make imports idempotent and cycle-safe per target space.
- Warn when a function definition arrives after that name was already compiled as a symbol.

## Provenance and compatibility adaptations

Original authorship and commit ordering are preserved. The commits were replayed onto `main` at `43705f5d9ff8958ffe7f0aa6777fb8477f2401f2`.

Current `main` changed library discovery after the original base. The replay therefore:

- retains current main's `standard_library_path/1` candidate for ordinary library lookup and its filtered `library_path/1` candidate for two-part lookup, while applying the original commit's existing-source preference; and
- declares the now-initially-empty `library_path/1` dynamic so git imports can test and register their canonical checkout before the first path exists.

No commits after `3f43640` are included. PR #203 and `import-overhaul` were not modified.

## Validation

- `UV_CACHE_DIR=/tmp/petta-uv-cache uv run pytest tests/test_imports.py` (managed environment, from `python/`): 2 passed
- `UV_CACHE_DIR=/tmp/petta-uv-cache uv run pytest tests` (managed environment, from `python/`): 9 passed
- `sh test.sh` (managed environment): all examples passed
- `git diff --check 43705f5d9ff8958ffe7f0aa6777fb8477f2401f2..HEAD`
