### PR TITLE
Split early import semantics commits into a new PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ python/__pycache__
 python/HE/__pycache__
 python/tests/__pycache__
 python/petta/__pycache__
+__pycache__/
+*.py[cod]
 
 # Python build artifacts
 build/

--- a/examples/import_duplicate_cycle.metta
+++ b/examples/import_duplicate_cycle.metta
@@ -1,0 +1,7 @@
+!(import! &self imports/overhaul/duplicate)
+!(import! &self ./imports/overhaul/./duplicate.metta)
+!(import! &self imports/overhaul/cycle_a)
+
+!(test (collapse (duplicate-import-result)) (loaded-once))
+!(test (cycle-a) a)
+!(test (cycle-b) b)

--- a/examples/import_error_surface.metta
+++ b/examples/import_error_surface.metta
@@ -1,0 +1,11 @@
+!(import! &self ../lib/lib_he)
+
+!(test (if-error (catch (import! &self imports/import_error_broken))
+                 Error
+                 NoError)
+       Error)
+
+!(test (if-error (catch (import! &self imports/definitely_missing_import))
+                 Error
+                 NoError)
+       Error)

--- a/examples/import_relative_nested.metta
+++ b/examples/import_relative_nested.metta
@@ -1,0 +1,4 @@
+!(import! &self imports/relative/root)
+
+!(test (from-sibling) 42)
+!(test (from-second) 7)

--- a/examples/import_space_identity.metta
+++ b/examples/import_space_identity.metta
@@ -1,0 +1,8 @@
+!(bind! &import-space-a (new-space))
+!(bind! &import-space-b (new-space))
+
+!(import! &import-space-a imports/overhaul/space_payload)
+!(import! &import-space-b imports/overhaul/space_payload)
+
+!(test (collapse (match &import-space-a (import-space-marker) present)) (present))
+!(test (collapse (match &import-space-b (import-space-marker) present)) (present))

--- a/examples/imports/import_error_broken.metta
+++ b/examples/imports/import_error_broken.metta
@@ -1,0 +1,1 @@
+(= (broken-import) a

--- a/examples/imports/overhaul/cycle_a.metta
+++ b/examples/imports/overhaul/cycle_a.metta
@@ -1,0 +1,3 @@
+!(import! &self cycle_b)
+
+(= (cycle-a) a)

--- a/examples/imports/overhaul/cycle_b.metta
+++ b/examples/imports/overhaul/cycle_b.metta
@@ -1,0 +1,3 @@
+!(import! &self ./cycle_a.metta)
+
+(= (cycle-b) b)

--- a/examples/imports/overhaul/duplicate.metta
+++ b/examples/imports/overhaul/duplicate.metta
@@ -1,0 +1,1 @@
+(= (duplicate-import-result) loaded-once)

--- a/examples/imports/overhaul/space_payload.metta
+++ b/examples/imports/overhaul/space_payload.metta
@@ -1,0 +1,1 @@
+(import-space-marker)

--- a/examples/imports/relative/root.metta
+++ b/examples/imports/relative/root.metta
@@ -1,0 +1,2 @@
+!(import! &self subdir/parent)
+!(import! &self second)

--- a/examples/imports/relative/second.metta
+++ b/examples/imports/relative/second.metta
@@ -1,0 +1,1 @@
+(= (from-second) 7)

--- a/examples/imports/relative/subdir/parent.metta
+++ b/examples/imports/relative/subdir/parent.metta
@@ -1,0 +1,2 @@
+!(import! &self sibling)
+!(import! &self python_helper.py)

--- a/examples/imports/relative/subdir/python_helper.py
+++ b/examples/imports/relative/subdir/python_helper.py
@@ -1,0 +1,1 @@
+"""Fixture proving Python imports resolve from the importing MeTTa file."""

--- a/examples/imports/relative/subdir/sibling.metta
+++ b/examples/imports/relative/subdir/sibling.metta
@@ -1,0 +1,1 @@
+(= (from-sibling) 42)

--- a/lib/lib_import.pl
+++ b/lib/lib_import.pl
@@ -84,13 +84,16 @@ replace_all(P, R, S, O) :- split_string(S, P, "", Parts),
 'git-import!'(GitPath, BuildCmd, true) :- 'git-import!'(GitPath, BuildCmd, './repos', true).
      
 'git-import!'(GitPath, BuildCmd, BaseDir, true) :- ( exists_directory(BaseDir) -> true
-                                                                                 ; format("What ~w~n", [BaseDir]), make_directory_path(BaseDir) ),
+                                                                                 ; make_directory_path(BaseDir) ),
                                                    repo_name_from_git(GitPath, Name),
                                                    directory_file_path(BaseDir, Name, LocalDir),
                                                    ( exists_directory(LocalDir) -> true
                                                                                  ; clone_repo(GitPath, LocalDir),
                                                                                    run_build_step(LocalDir, BuildCmd) ),
-                                                   asserta(library_path(LocalDir)).
+                                                   register_git_library_path(LocalDir).
+
+register_git_library_path(LocalDir) :- absolute_file_name(LocalDir, CanonDir, [file_type(directory), file_errors(fail)]),
+                                       ( library_path(CanonDir) -> true ; asserta(library_path(CanonDir)) ).
 
 % Reproducible import: URL, build command, base directory, full commit SHA.
 'git-import!'(GitPath, BuildCmd, BaseDir, CommitSHA, true) :-
@@ -259,19 +262,21 @@ repo_name_from_git(GitPath, Name) :- atom_string(GitPath, S),
                                      atom_string(Name, Last).
 
 clone_repo(GitPath, LocalDir) :- format("Cloning ~w into ~w~n", [GitPath, LocalDir]),
-                                 process_create(path(git),
-                                                ['clone', '--depth', '1', GitPath, LocalDir],
-                                                [stdout(pipe(Out)), stderr(pipe(Err))]),
-                                 read_string(Out, _, _),
-                                 read_string(Err, _, _),
-                                 close(Out), close(Err).
+                                 run_git_import_process(path(git),
+                                                        ['clone', '--depth', '1', GitPath, LocalDir],
+                                                        [],
+                                                        clone(GitPath)).
 
 run_build_step(_, BuildCmd) :- (BuildCmd = '' ; BuildCmd = ""), !.
 run_build_step(LocalDir, BuildCmd) :- format("Running build: ~w in ~w~n", [BuildCmd, LocalDir]),
-                                      process_create(path(sh),
-                                                     [BuildCmd],
-                                                     [cwd(LocalDir),
-                                                      stdout(pipe(Out)), stderr(pipe(Err))]),
-                                      read_string(Out, _, _),
-                                      read_string(Err, _, _),
-                                      close(Out), close(Err).
+                                      run_git_import_process(path(sh),
+                                                             [BuildCmd],
+                                                             [cwd(LocalDir)],
+                                                             build(BuildCmd)).
+
+run_git_import_process(Executable, Args, Options, Operation) :-
+    process_create(Executable, Args, [process(PID)|Options]),
+    process_wait(PID, Status),
+    ( Status = exit(0)
+      -> true
+       ; throw(error(process_error(Operation, Status), context('git-import!', Operation))) ).

--- a/python/helper.pl
+++ b/python/helper.pl
@@ -1,11 +1,6 @@
 maybe_enable_silent(true) :- !.
 maybe_enable_silent(false) :- assertz(silent(true)).
 
-set_working_dir(load_metta_file, File) :-
-    file_directory_name(File, Dir),
-    retractall(working_dir(_)),
-    assertz(working_dir(Dir)),
-    !.
 set_working_dir(_, _).
 
 run_metta_helper(Verbose, Predicate, Arg, ResultsR) :-

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -1,0 +1,24 @@
+import uuid
+
+import pytest
+
+
+def test_failed_import_can_be_retried(petta_instance, tmp_path):
+    module_name = f"petta_retry_{uuid.uuid4().hex}"
+    root_file = tmp_path / "root.metta"
+    dependency_file = tmp_path / "dependency.metta"
+    python_file = tmp_path / f"{module_name}.py"
+
+    root_file.write_text("!(import! &self dependency)\n!(retry-result)\n")
+    dependency_file.write_text(
+        f'!(import! &self "{module_name}.py")\n(= (retry-result) retry-ok)\n'
+    )
+    python_file.write_text('raise RuntimeError("first import fails")\n')
+
+    with pytest.raises(Exception, match="first import fails"):
+        petta_instance.load_metta_file(str(root_file))
+
+    python_file.write_text("RETRY_SUCCEEDED = True\n")
+    results = petta_instance.load_metta_file(str(root_file))
+
+    assert "retry-ok" in results

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -22,3 +22,25 @@ def test_failed_import_can_be_retried(petta_instance, tmp_path):
     results = petta_instance.load_metta_file(str(root_file))
 
     assert "retry-ok" in results
+
+
+def test_import_after_use_warns(petta_instance, tmp_path, capfd):
+    fn = f"late_inc_{uuid.uuid4().hex}"
+    root_file = tmp_path / "root.metta"
+    dependency_file = tmp_path / "dependency.metta"
+
+    dependency_file.write_text(f"(= ({fn} $x) (+ $x 1))\n")
+    root_file.write_text(
+        f"(= (uses-{fn} $x) ({fn} $x))\n"
+        "!(import! &self dependency)\n"
+        f"!(uses-{fn} 41)\n"
+    )
+
+    results = petta_instance.load_metta_file(str(root_file))
+    stderr = capfd.readouterr().err
+
+    # The definition compiled before the import treats the name as a plain symbol...
+    assert f"({fn} 41)" in results
+    # ...and the late registration is called out.
+    assert fn in stderr
+    assert "Move the import or definition above the first use" in stderr

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -2,11 +2,23 @@
 :- use_module(library(pcre)). % re_replace/4
 :- current_prolog_flag(argv, Args), ( (memberchk(silent, Args) ; memberchk('--silent', Args) ; memberchk('-s', Args))
                                       -> assertz(silent(true)) ; assertz(silent(false)) ).
+:- dynamic working_dir/1.
+
+push_working_dir(Filename) :- file_directory_name(Filename, Dir0),
+                              ( absolute_file_name(Dir0, Dir, [file_type(directory), file_errors(fail)])
+                                -> true
+                                 ; Dir = Dir0 ),
+                              asserta(working_dir(Dir)).
+
+pop_working_dir :- retract(working_dir(_)), !.
+pop_working_dir.
 
 %Read Filename into string S and process it (S holds MeTTa code):
 load_metta_file(Filename, Results) :- load_metta_file(Filename, Results, '&self').
-load_metta_file(Filename, Results, Space) :- read_file_to_string(Filename, S, []),
-                                             process_metta_string(S, Results, Space).
+load_metta_file(Filename, Results, Space) :- setup_call_cleanup(push_working_dir(Filename),
+                                                                ( read_file_to_string(Filename, S, []),
+                                                                  process_metta_string(S, Results, Space) ),
+                                                                pop_working_dir).
 
 %Extract function definitions, call invocations, and S-expressions part of &self space:
 process_metta_string(S, Results) :- process_metta_string(S, Results, '&self').

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -39,9 +39,22 @@ process_metta_string(S, Results, Space) :- string_codes(S, Cs),
                                            maplist(process_form(Space), ParsedForms, ResultsList), !,
                                            append(ResultsList, Results).
 
+register_function_signature(F, Arity) :- warn_if_used_as_symbol(F),
+                                         register_fun(F),
+                                         ( catch(arity(F, Arity), _, fail) -> true ; assertz(arity(F, Arity)) ).
+
+%A function arriving after expressions already compiled its name as a plain symbol
+%cannot be called by those expressions anymore, which usually means an import came too late:
+warn_if_used_as_symbol(F) :- \+ fun(F), symbol_head(F), !,
+                             format(user_error, "Warning: ~w is defined or imported after already being used; earlier expressions treat it as a plain symbol. Move the import or definition above the first use.~n", [F]).
+warn_if_used_as_symbol(_).
+
 %First pass to convert MeTTa to Prolog Terms and register functions:
 parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
-                                           ( Term = [=, [F|W], _], atom(F) -> register_fun(F), length(W, N), Arity is N + 1, assertz(arity(F,Arity)), T=function
+                                           ( Term = [=, [F|W], _], atom(F) -> length(W, N),
+                                                                              Arity is N + 1,
+                                                                              register_function_signature(F, Arity),
+                                                                              T=function
                                                                             ; T=expression ).
 parse_form(runnable(S), parsed(runnable, S, Term)) :- sread(S, Term).
 

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -15,10 +15,20 @@ pop_working_dir.
 
 %Read Filename into string S and process it (S holds MeTTa code):
 load_metta_file(Filename, Results) :- load_metta_file(Filename, Results, '&self').
-load_metta_file(Filename, Results, Space) :- setup_call_cleanup(push_working_dir(Filename),
-                                                                ( read_file_to_string(Filename, S, []),
-                                                                  process_metta_string(S, Results, Space) ),
-                                                                pop_working_dir).
+load_metta_file(Filename, Results, Space) :- catch(load_metta_file_impl(Filename, Results, Space),
+                                                   Error,
+                                                   rethrow_metta_file_error(Filename, Error)).
+
+load_metta_file_impl(Filename, Results, Space) :- setup_call_cleanup(push_working_dir(Filename),
+                                                                     ( read_file_to_string(Filename, S, []),
+                                                                       process_metta_string(S, Results, Space) ),
+                                                                     pop_working_dir).
+
+rethrow_metta_file_error(_, Error) :- Error = error(_, context(_, _)), !,
+                                      throw(Error).
+rethrow_metta_file_error(Filename, error(Type, _)) :- !,
+                                                      throw(error(Type, context(Filename, 'while loading MeTTa file'))).
+rethrow_metta_file_error(_, Error) :- throw(Error).
 
 %Extract function definitions, call invocations, and S-expressions part of &self space:
 process_metta_string(S, Results) :- process_metta_string(S, Results, '&self').

--- a/src/main.pl
+++ b/src/main.pl
@@ -25,9 +25,7 @@ main :- current_prolog_flag(argv, RawArgs),
         ( Args = [] -> prolog_interop_example
         ; Args = [mork] -> prolog_interop_example,
                            mork_test
-        ; Args = [File|_] -> file_directory_name(File, Dir),
-                             assertz(working_dir(Dir)),
-                             load_metta_file(File,Results),
+        ; Args = [File|_] -> load_metta_file(File,Results),
                              maplist(swrite,Results,ResultsR),
                              maplist(format("~w~n"), ResultsR)
         ),

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -301,9 +301,12 @@ retractPredicate(_, false).
 ensure_metta_ext(Path, Path) :- file_name_extension(_, metta, Path), !.
 ensure_metta_ext(Path, PathWithExt) :- file_name_extension(Path, metta, PathWithExt).
 
+current_working_dir(Base) :- working_dir(Base), !.
+current_working_dir(Base) :- absolute_file_name('.', Base, [file_type(directory)]).
+
 'import!'(Space, File, true) :- catch(importer_helper(Space, File), _, fail).
 importer_helper(Space, File) :- atom_string(File, SFile),
-                                working_dir(Base),
+                                current_working_dir(Base),
                                 ( file_name_extension(ModPath, 'py', SFile)
                                   -> absolute_file_name(SFile, Path, [relative_to(Base)]),
                                      file_directory_name(Path, Dir),

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -1,6 +1,21 @@
 %%%%%%%%%% Dependencies %%%%%%%%%%
-library(X, Path) :- standard_library_path(Base), atomic_list_concat([Base, '/', X], Path).
-library(X, Y, Path) :- library_path(Base), atom_concat(_, X, Base), atomic_list_concat([Base, '/', Y], Path).
+library(X, Path) :- resolve_library_path(library_path_candidate(X), Path).
+library(X, Y, Path) :- resolve_library_path(library_path_candidate(X, Y), Path).
+
+library_path_candidate(X, Path) :- standard_library_path(Base),
+                                   atomic_list_concat([Base, '/', X], Path).
+library_path_candidate(X, Y, Path) :- library_path(Base),
+                                      atom_concat(_, X, Base),
+                                      atomic_list_concat([Base, '/', Y], Path).
+
+resolve_library_path(Candidate, Path) :- ( once((call(Candidate, ExistingPath),
+                                                  library_source_exists(ExistingPath)))
+                                           -> Path = ExistingPath
+                                            ; once(call(Candidate, Path)) ).
+
+library_source_exists(Path) :- exists_file(Path), !.
+library_source_exists(Path) :- file_name_extension(Path, metta, MettaPath),
+                               exists_file(MettaPath).
 :- prolog_load_context(directory, Source),
    directory_file_path(Source, '..', Parent),
    directory_file_path(Parent, 'lib', LibPath),
@@ -304,19 +319,50 @@ ensure_metta_ext(Path, PathWithExt) :- file_name_extension(Path, metta, PathWith
 current_working_dir(Base) :- working_dir(Base), !.
 current_working_dir(Base) :- absolute_file_name('.', Base, [file_type(directory)]).
 
-'import!'(Space, File, true) :- catch(importer_helper(Space, File), _, fail).
-importer_helper(Space, File) :- atom_string(File, SFile),
-                                current_working_dir(Base),
-                                ( file_name_extension(ModPath, 'py', SFile)
-                                  -> absolute_file_name(SFile, Path, [relative_to(Base)]),
-                                     file_directory_name(Path, Dir),
-                                     file_base_name(ModPath, ModuleName),
-                                     py_call(sys:path:append(Dir), _),
-                                     py_call(builtins:'__import__'(ModuleName), _)
-                                   ; ( Path = SFile ; atomic_list_concat([Base, '/', SFile], Path) ),
-                                     ensure_metta_ext(Path, PathWithExt),
-                                     exists_file(PathWithExt), !,
-                                     load_metta_file(PathWithExt, _, Space) ).
+import_file_string(File, SFile) :- string(File), !, SFile = File.
+import_file_string(File, SFile) :- atom_string(File, SFile).
+
+python_import_file(File) :- import_file_string(File, SFile),
+                            file_name_extension(_, py, SFile).
+
+resolve_existing_import_path(Base, RequestedPath, CanonPath) :-
+    absolute_file_name(RequestedPath, CanonPath,
+                       [relative_to(Base), access(read), file_errors(fail)]), !.
+resolve_existing_import_path(_, RequestedPath, CanonPath) :-
+    absolute_file_name(RequestedPath, CanonPath,
+                       [access(read), file_errors(fail)]), !.
+
+throw_missing_import(File) :-
+    throw(error(existence_error(source_sink, File), context('import!', File))).
+
+resolve_metta_import_path(File, CanonPath) :-
+    import_file_string(File, SFile),
+    \+ python_import_file(SFile),
+    current_working_dir(Base),
+    ensure_metta_ext(SFile, RequestedPath),
+    ( resolve_existing_import_path(Base, RequestedPath, CanonPath)
+      -> true
+       ; throw_missing_import(File) ).
+
+resolve_python_import_path(File, CanonPath) :-
+    import_file_string(File, SFile),
+    python_import_file(SFile),
+    current_working_dir(Base),
+    ( resolve_existing_import_path(Base, SFile, CanonPath)
+      -> true
+       ; throw_missing_import(File) ).
+
+'import!'(Space, File, true) :- importer_helper(Space, File).
+importer_helper(Space, File) :-
+    ( python_import_file(File)
+      -> resolve_python_import_path(File, CanonPath),
+         file_directory_name(CanonPath, Dir),
+         file_base_name(CanonPath, BaseName),
+         file_name_extension(ModuleName, _, BaseName),
+         py_call(sys:path:append(Dir), _),
+         py_call(builtins:'__import__'(ModuleName), _)
+       ; resolve_metta_import_path(File, CanonPath),
+         load_metta_file(CanonPath, _, Space) ).
 
 :- dynamic translator_rule/1.
 'add-translator-rule!'(HV, true) :- ( translator_rule(HV)

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -352,6 +352,30 @@ resolve_python_import_path(File, CanonPath) :-
       -> true
        ; throw_missing_import(File) ).
 
+:- dynamic metta_import_state/3.
+
+% A loading entry breaks cycles; a loaded entry makes later imports no-ops.
+% Failed loads remove their entry so callers can repair the source and retry.
+claim_import(Space, CanonPath, skip) :- metta_import_state(Space, CanonPath, loaded), !.
+claim_import(Space, CanonPath, skip) :- metta_import_state(Space, CanonPath, loading), !.
+claim_import(Space, CanonPath, load) :- assertz(metta_import_state(Space, CanonPath, loading)).
+
+clear_import_state(Space, CanonPath) :- retractall(metta_import_state(Space, CanonPath, _)).
+
+mark_import_loaded(Space, CanonPath) :- clear_import_state(Space, CanonPath),
+                                        assertz(metta_import_state(Space, CanonPath, loaded)).
+
+run_new_import(Space, CanonPath, Goal) :-
+    catch(( once(Goal)
+            -> mark_import_loaded(Space, CanonPath)
+             ; clear_import_state(Space, CanonPath), fail ),
+          Error,
+          ( clear_import_state(Space, CanonPath), throw(Error) )).
+
+import_once(Space, CanonPath, Goal) :- claim_import(Space, CanonPath, Action),
+                                       ( Action = skip -> true
+                                                       ; run_new_import(Space, CanonPath, Goal) ).
+
 'import!'(Space, File, true) :- importer_helper(Space, File).
 importer_helper(Space, File) :-
     ( python_import_file(File)
@@ -359,10 +383,11 @@ importer_helper(Space, File) :-
          file_directory_name(CanonPath, Dir),
          file_base_name(CanonPath, BaseName),
          file_name_extension(ModuleName, _, BaseName),
-         py_call(sys:path:append(Dir), _),
-         py_call(builtins:'__import__'(ModuleName), _)
+         import_once(Space, CanonPath,
+                     ( py_call(sys:path:append(Dir), _),
+                       py_call(builtins:'__import__'(ModuleName), _) ))
        ; resolve_metta_import_path(File, CanonPath),
-         load_metta_file(CanonPath, _, Space) ).
+         import_once(Space, CanonPath, load_metta_file(CanonPath, _, Space)) ).
 
 :- dynamic translator_rule/1.
 'add-translator-rule!'(HV, true) :- ( translator_rule(HV)

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -1,4 +1,6 @@
 %%%%%%%%%% Dependencies %%%%%%%%%%
+:- dynamic library_path/1.
+
 library(X, Path) :- resolve_library_path(library_path_candidate(X), Path).
 library(X, Y, Path) :- resolve_library_path(library_path_candidate(X, Y), Path).
 

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -39,6 +39,11 @@ translate_clause(Input, (Head :- BodyConj), ConstrainArgs) :-
                                                append(GoalsPrefix, FinalGoals, Goals),
                                                goals_list_to_conj(Goals, BodyConj).
 
+%Record atoms compiled as plain symbol heads, so late function registrations can be flagged:
+:- dynamic symbol_head/1.
+note_symbol_head(HV) :- atom(HV), \+ symbol_head(HV), !, assertz(symbol_head(HV)).
+note_symbol_head(_).
+
 %Print compiled clause:
 maybe_print_compiled_clause(_, _, _) :- silent(true), !.
 maybe_print_compiled_clause(Label, FormTerm, Clause) :-
@@ -350,7 +355,8 @@ translate_expr([H0|T0], Goals, Out) :-
                          Goals = [Disj] )
               ; build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
           %Literals (numbers, strings, etc.), known non-function atom => data:
-          ; ( atomic(HV), \+ atom(HV) ; atom(HV), \+ fun(HV) ) -> Out = [HV|AVs],
+          ; ( atomic(HV), \+ atom(HV) ; atom(HV), \+ fun(HV) ) -> note_symbol_head(HV),
+                                                                  Out = [HV|AVs],
                                                                   Goals = Inner
           %Plain data list: evaluate inner fun-sublists
           ; is_list(HV) -> eval_data_term(HV, Gd, HV1),


### PR DESCRIPTION
<!-- myclaw:managed-pr-description:v1 -->

## Summary

Published draft PR #214 (https://github.com/trueagi-io/PeTTa/pull/214) from agent/split-early-import-semantics onto main 43705f5d9ff8958ffe7f0aa6777fb8477f2401f2. Exactly five replayed commits preserve original authorship and include only two documented current-main compatibility adaptations. PR #203 remained open at unchanged import-overhaul SHA 4843144ba569a896991fc6d84a30f1136488fee1.

## Why

PR #203 currently combines an early coherent set of import-loading changes with later work that may be heavily reworked. The user wants everything through and including commit 3f43640ce36db30eeb96307531a51a50f16f3ba0 split into a separate PR rebased onto latest main, while leaving PR #203 unchanged for now.

## Validation

- Managed import-focused Python tests: 2 passed
- Managed full Python suite: 9 passed
- Managed full example suite: all examples passed
- git diff --check base..head: passed
- Post-publication #214 readback verified draft/base/head

## Decisions

- Retain current main's library lookup candidates while applying the original existing-source preference.
- Declare library_path/1 dynamic within the fourth replayed commit.

## Risks

- Isolated temporary Git metadata was required due to the read-only linked index; published state was read back and durable checkout was untouched.

## Assumptions

- Verified five-commit linear boundary.
- Remote main remained at 43705f5 through publication.

## MyClaw provenance

- Task: `task_ed4fd5b1a20f41dc`
- Reviewed commit: `6e2c4c92b66bd7badc3ed94a1299ad37a5fecc71`
- Decision fingerprint: `39b4267b4ce96dc6197ba343df836d1536160c9b02e6d4755156a90251e20499`

<!-- /myclaw:managed-pr-description -->