### PR TITLE
Prevent duplicate MeTTa file imports

### DIFF
--- a/python/tests/data/duplicate_import/child.metta
+++ b/python/tests/data/duplicate_import/child.metta
@@ -1,0 +1,1 @@
+(= (duplicate-test) 42)

--- a/python/tests/data/duplicate_import/main.metta
+++ b/python/tests/data/duplicate_import/main.metta
@@ -1,0 +1,3 @@
+!(import! &self child)
+!(import! &self ./child)
+!(test (duplicate-test) 42)

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -298,6 +298,7 @@ retractPredicate(G, true) :- retract(G), !.
 retractPredicate(_, false).
 
 %%% Library / Import: %%%
+:- dynamic imported_file/1.
 ensure_metta_ext(Path, Path) :- file_name_extension(_, metta, Path), !.
 ensure_metta_ext(Path, PathWithExt) :- file_name_extension(Path, metta, PathWithExt).
 
@@ -311,10 +312,15 @@ importer_helper(Space, File) :- atom_string(File, SFile),
                                      py_call(sys:path:append(Dir), _),
                                      py_call(builtins:'__import__'(ModuleName), _)
                                    ; ( Path = SFile ; atomic_list_concat([Base, '/', SFile], Path) ),
-                                     ensure_metta_ext(Path, PathWithExt),
-                                     exists_file(PathWithExt), !,
-                                     load_metta_file(PathWithExt, _, Space) ).
-
+                                    ensure_metta_ext(Path, PathWithExt),
+                                    exists_file(PathWithExt),
+                                    absolute_file_name(PathWithExt, AbsolutePath),
+                                    ( imported_file(AbsolutePath)
+                                      -> true
+                                      ; assertz(imported_file(AbsolutePath)),
+                                        load_metta_file(AbsolutePath, _, Space)
+                                    )
+                    ).
 :- dynamic translator_rule/1.
 'add-translator-rule!'(HV, true) :- ( translator_rule(HV)
                                       -> true ; assertz(translator_rule(HV)) ).

--- a/test.sh
+++ b/test.sh
@@ -20,7 +20,19 @@ run_test() {
         return 0
     fi
 }
+run_duplicate_import_test() {
+    echo "Running duplicate import regression test"
+    output=$(sh run.sh python/tests/data/duplicate_import/main.metta)
+    echo "$output"
 
+    if ! echo "$output" | grep -q "is 42, should 42. ✅"; then
+        echo "FAILURE in duplicate import regression test"
+        return 1
+    fi
+
+    echo "OK: duplicate import regression test"
+}
+run_duplicate_import_test || exit 1
 pids=""
 pidfile="/tmp/metta_pid_map.$$"
 : > "$pidfile"


### PR DESCRIPTION
## Description

This PR prevents `import!` from loading the same MeTTa file multiple times.

When a MeTTa file is imported more than once, the file can be processed and
its definitions can be registered repeatedly. This can cause problems when
the same file is imported again, especially when the same file is referenced
using different path forms.

For example:

```metta
!(import! &self child)
!(import! &self ./child)