### PR TITLE
Fix/spaces primitive atoms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-python/__pycache__
-python/HE/__pycache__
-python/tests/__pycache__
-python/petta/__pycache__
+__pycache__/
+repos/
 
 # Python build artifacts
 build/

--- a/examples/test_add_primitive.metta
+++ b/examples/test_add_primitive.metta
@@ -1,0 +1,6 @@
+!(add-atom &space "Hello")
+!(add-atom &space 42)
+!(add-atom &space (A B))
+
+; This will list all atoms currently in the space
+!(match &space $x $x)

--- a/src/spaces.pl
+++ b/src/spaces.pl
@@ -1,10 +1,12 @@
 %Since both normal add-attom call and function additions needs to add the S-expression:
-add_sexp(Space, [Rel|Args]) :- Term =.. [Space, Rel | Args],
-                               assertz(Term).
+add_sexp(Space, TermIn) :- ( is_list(TermIn), TermIn = [Rel|Args] -> Term =.. [Space, Rel | Args]
+                                                                  ; Term =.. [Space, '#primitive', TermIn] ),
+                           assertz(Term).
 
 %Same but for removal:
-remove_sexp(Space, [Rel|Args]) :- Term =.. [Space, Rel | Args],
-                                  retractall(Term).
+remove_sexp(Space, TermIn) :- ( is_list(TermIn), TermIn = [Rel|Args] -> Term =.. [Space, Rel | Args]
+                                                                     ; Term =.. [Space, '#primitive', TermIn] ),
+                              retractall(Term).
 
 %Add a function atom:
 'add-atom'(Space, Term, true) :- Term = [=,[FAtom|W],_], !,
@@ -47,8 +49,8 @@ remove_sexp(Space, [Rel|Args]) :- Term =.. [Space, Rel | Args],
 match(_, LComma, OutPattern, Result) :- LComma == [','], !,
                                         Result = OutPattern.
 match(Space, [Comma|[Head|Tail]], OutPattern, Result) :- Comma == ',', !,
-                                                         append([Space], Head, List),
-                                                         Term =.. List,
+                                                         ( is_list(Head) -> append([Space], Head, List), Term =.. List
+                                                                          ; Term =.. [Space, '#primitive', Head] ),
                                                          catch(Term, _, fail),
                                                          \+ cyclic_term(OutPattern),
                                                          match(Space, [','|Tail], OutPattern, Result).
@@ -60,13 +62,15 @@ match(Space, PatternVar, OutPattern, Result) :- var(PatternVar), !,
                                                 Result = OutPattern.
 
 %Match for pattern:
-match(Space, [Rel|PatArgs], OutPattern, Result) :- Term =.. [Space, Rel | PatArgs],
-                                                   catch(Term, _, fail),
-                                                   \+ cyclic_term(OutPattern),
-                                                   Result = OutPattern.
+match(Space, Pattern, OutPattern, Result) :- ( is_list(Pattern), Pattern = [Rel|PatArgs] -> Term =.. [Space, Rel | PatArgs]
+                                                                                          ; Term =.. [Space, '#primitive', Pattern] ),
+                                             catch(Term, _, fail),
+                                             \+ cyclic_term(OutPattern),
+                                             Result = OutPattern.
 
 %Get all atoms in space, irregard of arity:
 'get-atoms'(Space, Pattern) :- current_predicate(Space/Arity),
                                functor(Head, Space, Arity),
                                clause(Head, true),
-                               Head =.. [Space | Pattern].
+                               Head =.. [Space | Args],
+                               ( Args = ['#primitive', P] -> Pattern = P ; Pattern = Args ).


### PR DESCRIPTION
### What this PR does
1. **Fixes `add-atom` dropping primitive values.** Previously, `spaces.pl` strictly expected incoming atoms to be S-Expression lists (`[Rel|Args]`). Adding a scalar primitive (like `42` or `"Hello"`) would silently fail unification and be dropped. This PR wraps non-list atoms using an internal `#primitive` marker when asserting them to the Prolog database, and unwraps them during `get-atoms` and `match` operations.
2. **Cleans up `.gitignore`.** Replaced the specific `__pycache__` directory rules with a global `__pycache__/` rule, and ignored the dynamically generated `repos/` folder to keep untracked files clean.

### Changes
- `src/spaces.pl`: Added list-checking in `add_sexp`, `remove_sexp`, and `match`, ensuring primitives are safely stored and queried.
- `.gitignore`: Globalized `__pycache__` and added `repos/`.
- Added `examples/test_add_primitive.metta` to the automated test suite to prevent regressions.

### Testing
- Primitives (`42`, `"Hello"`, `true`) are now successfully added and returned from `!(match &space $x $x)`.
- Verified that all existing tests in `sh test.sh` continue to pass without regressions.