### PR TITLE
fix(parser): preserve variable identity across swrite GC

### DIFF
--- a/examples/swrite_variable_identity.metta
+++ b/examples/swrite_variable_identity.metta
@@ -1,0 +1,30 @@
+;; Serialized variable identity, asserted behaviorally -- no naming scheme
+;; is assumed anywhere in this file.
+;; (Compact form of the sharing shape from Nil's OBC S13 enumeration.)
+
+(= (countdown $n)
+   (if (< 0 $n)
+       (cons $n (countdown (- $n 1)))
+       ()))
+
+(= (padded-ax1 $p $q)
+   (: ax1 (-> $p (-> $q $p))))
+
+(= (two-vars $p $q)
+   (: pair (-> $p $q)))
+
+;; 1. Distinctness survives the round trip: two distinct variables must
+;;    re-parse as distinct, i.e. bindable to different constants.
+!(test (case (parse (repr (two-vars $a $b)))
+             (((: pair (-> 7 8)) distinct-preserved)
+              ($other fabricated-sharing)))
+       distinct-preserved)
+
+;; 2. Sharing survives the round trip: if the two occurrences of one
+;;    variable print under different names, the re-parsed term has two
+;;    independent variables, which CAN bind to the different constants
+;;    1 and 2 -- the first case branch fires and reports the split.
+!(test (case (parse (repr (padded-ax1 $shared (countdown 2000))))
+             (((: ax1 (-> 1 (-> $pad 2))) split-detected)
+              ($other sharing-preserved)))
+       sharing-preserved)

--- a/src/parser.pl
+++ b/src/parser.pl
@@ -1,18 +1,46 @@
 :- use_module(library(dcg/basics)). %blanks/0, number/1, string_without/2
 
 %Generate a MeTTa S-expression string from the Prolog list (inverse parsing):
-swrite(Term, String) :- phrase(swrite_exp(Term), Codes),
-                        string_codes(String, Codes).
-swrite_exp(Var)   --> { var(Var) }, !, "$", { term_to_atom(Var, A), atom_codes(A, Cs) }, Cs.
-swrite_exp(Num)   --> { number(Num) }, !, { number_codes(Num, Cs) }, Cs.
-swrite_exp(Str)   --> { string(Str) }, !, "\"", { string_codes(Str, Cs), escape_quotes(Cs, Es) }, Es, "\"".
-swrite_exp(Atom)  --> { atom(Atom) }, !, atom(Atom).
-swrite_exp([H|T]) --> { \+ is_list([H|T]) }, !, "(", atom(cons), " ", swrite_exp(H), " ", swrite_exp(T), ")".
-swrite_exp([H|T]) --> !, "(", seq([H|T]), ")".
-swrite_exp([])    --> !, "()".
-swrite_exp(Term)  --> { Term =.. [F|Args] }, "(", atom(F), ( { Args == [] } -> [] ; " ", seq(Args) ), ")".
-seq([X])    --> swrite_exp(X).
-seq([X|Xs]) --> swrite_exp(X), " ", seq(Xs).
+%Variable names are minted from a per-call counter in first-occurrence order and
+%cached on the variable itself (an attribute travels with the variable through
+%GC, unlike SWI's internal display name, and lookup is O(1)).  Counter names
+%make the two printing invariants hold by construction: one variable never
+%prints under two names, and two variables never print under one.
+swrite(Term, String) :-
+        setup_call_cleanup(true,
+            ( phrase(swrite_exp(Term, 0, _), Codes),
+              string_codes(String, Codes) ),
+            swrite_cleanup(Term)).
+
+swrite_cleanup(Term) :-
+        term_attvars(Term, Vars),
+        maplist([V]>>del_attr(V, petta_swrite_name), Vars).
+
+%The attribute carries serializer-local identity only.  A caller may alias the
+%output with an input variable, so unification may reach this hook; it imposes
+%no constraint on the value.
+petta_swrite_name:attr_unify_hook(_, _).
+
+swrite_exp(Var, C0, C)   --> { var(Var) }, !, "$_",
+                              { (   get_attr(Var, petta_swrite_name, N)
+                                ->  C = C0
+                                ;   N = C0, C is C0 + 1,
+                                    put_attr(Var, petta_swrite_name, N)
+                                ),
+                                number_codes(N, Cs) }, Cs.
+swrite_exp(Num, C, C)    --> { number(Num) }, !, { number_codes(Num, Cs) }, Cs.
+swrite_exp(Str, C, C)    --> { string(Str) }, !, "\"",
+                              { string_codes(Str, Cs), escape_quotes(Cs, Es) }, Es, "\"".
+swrite_exp(Atom, C, C)   --> { atom(Atom) }, !, atom(Atom).
+swrite_exp([H|T], C0, C) --> { \+ is_list([H|T]) }, !, "(", atom(cons), " ",
+                              swrite_exp(H, C0, C1), " ", swrite_exp(T, C1, C), ")".
+swrite_exp([H|T], C0, C) --> !, "(", swrite_seq([H|T], C0, C), ")".
+swrite_exp([], C, C)     --> !, "()".
+swrite_exp(Term, C0, C)  --> { Term =.. [F|Args] }, "(", atom(F),
+                              ( { Args == [] } -> { C = C0 }
+                              ; " ", swrite_seq(Args, C0, C) ), ")".
+swrite_seq([X], C0, C)    --> swrite_exp(X, C0, C).
+swrite_seq([X|Xs], C0, C) --> swrite_exp(X, C0, C1), " ", swrite_seq(Xs, C1, C).
 escape_quotes([], []).
 escape_quotes([0'\\|T], [0'\\,0'\\|R]) :- !, escape_quotes(T, R).
 escape_quotes([0'"|T], [0'\\,0'"|R]) :- !, escape_quotes(T, R).

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+swipl -q -s tests/test_parser_swrite.pl -g run_tests -t halt || exit 1
+
 run_test() {
     f="$1"
     echo "Running $f"

--- a/tests/test_parser_swrite.pl
+++ b/tests/test_parser_swrite.pl
@@ -1,0 +1,55 @@
+:- begin_tests(parser_swrite).
+
+:- ensure_loaded('../src/parser.pl').
+
+test(repeated_variable_round_trip) :-
+        once(swrite([pair, X, X], Text)),
+        once(sread(Text, Parsed)),
+        Parsed = [pair, A, B],
+        A == B.
+
+test(distinct_variables_round_trip) :-
+        once(swrite([pair, _X, _Y], Text)),
+        once(sread(Text, Parsed)),
+        Parsed = [pair, A, B],
+        A \== B.
+
+% Counter-minted names do not depend on stack addresses, so the printed
+% text is identical before and after a collection.
+test(text_stable_across_gc) :-
+        Term = [pair, X, X],
+        once(swrite(Term, Before)),
+        garbage_collect,
+        once(swrite(Term, After)),
+        Before == After.
+
+% Many distinct variables must stay distinct after a round trip: if any
+% two printed under one name, sread would merge them.
+test(many_distinct_variables_stay_distinct) :-
+        length(Vs, 4000),
+        once(swrite([vs|Vs], Text)),
+        once(sread(Text, Parsed)),
+        Parsed = [vs|Ps],
+        sort(Ps, Sorted),
+        length(Ps, N), length(Sorted, N).
+
+% The naming attribute must not survive the call.
+test(no_attribute_residue) :-
+        once(swrite([pair, X, X], _)),
+        \+ attvar(X).
+
+test(unrelated_attribute_survives) :-
+        freeze(X, throw(unexpected_wakeup)),
+        frozen(X, Before),
+        once(swrite([pair, X, X], _)),
+        frozen(X, After),
+        Before =@= After.
+
+test(output_may_alias_input_variable) :-
+        once(swrite([pair, X], X)),
+        string(X),
+        once(sread(X, Parsed)),
+        Parsed = [pair, Y],
+        var(Y).
+
+:- end_tests(parser_swrite).


### PR DESCRIPTION
We found a strange bug in shared variables becoming decoupled when working on CeTTa --lang petta on Nil's chaining bechmarks.  This var_id style fix seems to work and possibly improve performance.  Feel free to edit the code however you please.

---

Codex Sol: 
 
 ## Problem

  `swrite/2` generated variable names using `term_to_atom/2`. These names
  reflect movable SWI-Prolog stack locations.

  If garbage collection occurred during serialization:

  - one logical variable could print under two names, splitting sharing;
  - distinct variables could print under one name, fabricating sharing.

  Reparsing the output then changes its semantics.

  Minimal witness shape:

  ```text
  (: ax1 (-> $X (-> <padding> $X)))

  Upstream printed the two occurrences differently:

  (: ax1 (-> $_9240 (-> <padding> $_262)))

  This change preserves their identity:

  (: ax1 (-> $_0 (-> <padding> $_0)))

  The MeTTa regression example demonstrates the behavioral difference:

  Upstream:
  is distinct-preserved, should distinct-preserved. ✅
  is split-detected, should sharing-preserved. ❌

  Fixed:
  is distinct-preserved, should distinct-preserved. ✅
  is sharing-preserved, should sharing-preserved. ✅

  ## Fix

  Variable names are minted from a per-call counter and cached temporarily
  on each Prolog variable as an attribute. Attributes follow logical
  variables across moving garbage collection.

  Cleanup removes the temporary attribute without disturbing unrelated
  attributes. The generated naming is deterministic, but the tests depend
  only on preservation of sharing and distinctness.

  ## Verification

  - focused serializer tests: 7/7 pass;
  - full PeTTa example suite passes;
  - Nil OBC S13 returns all 35,063 ordered answers with correct sharing;
  - large distinct-variable stress test produces no name collisions.