### PR TITLE
Fix/minimal space owned eval 20260827

### DIFF
--- a/examples/late_type_coherence.metta
+++ b/examples/late_type_coherence.metta
@@ -1,0 +1,17 @@
+; A caller sees a type declaration even when the declaration appears later.
+(= (typed-through $x) (typed-identity $x))
+(: typed-identity (-> Number Number))
+(= (typed-identity $x) $x)
+
+!(test (collapse (typed-through 7)) (7))
+!(test (collapse (typed-through "bad")) ())
+
+; Adding and removing a type updates callers that are already compiled.
+(= (dynamic-identity $x) $x)
+(= (dynamic-through $x) (dynamic-identity $x))
+
+!(test (collapse (dynamic-through "before")) ("before"))
+!(add-atom &self (: dynamic-identity (-> Number Number)))
+!(test (collapse (dynamic-through "after-add")) ())
+!(remove-atom &self (: dynamic-identity (-> Number Number)))
+!(test (collapse (dynamic-through "after-remove")) ("after-remove"))

--- a/examples/space_ownership.metta
+++ b/examples/space_ownership.metta
@@ -1,0 +1,13 @@
+; Store the same equation under two independent owners.
+!(bind! &foo (new-space))
+!(add-atom &self (= (f) 1))
+!(add-atom &foo (= (f) 1))
+
+; Default evaluation uses &self; eval/2 selects &foo explicitly.
+!(test (collapse (f)) (1))
+!(test (eval (f) &foo) 1)
+
+; Removing &foo's copy leaves &self's data and executable behavior intact.
+!(remove-atom &foo (= (f) 1))
+!(test (match &self (= (f) $result) $result) 1)
+!(test (collapse (f)) (1))

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -13,39 +13,41 @@ process_metta_string(S, Results) :- process_metta_string(S, Results, '&self').
 process_metta_string(S, Results, Space) :- string_codes(S, Cs),
                                            strip(Cs, 0, Codes),
                                            phrase(top_forms(Forms, 1), Codes),
-                                           maplist(parse_form, Forms, ParsedForms),
+                                           maplist(parse_form(Space), Forms, ParsedForms),
                                            findall(F-TypeChain,
-                                                   ( Space == '&self',
-                                                     member(parsed(expression, _, Term), ParsedForms),
+                                                   ( member(parsed(expression, _, Term), ParsedForms),
                                                      function_type_annotation_term(Term, F, TypeChain) ),
                                                    PredeclaredTypes),
-                                           with_predeclared_function_types(
+                                           with_predeclared_function_types(Space,
                                                PredeclaredTypes,
-                                               maplist(process_form(Space), ParsedForms, ResultsList)), !,
+                                               with_translation_space(Space,
+                                                   maplist(process_form(Space), ParsedForms, ResultsList))), !,
                                            append(ResultsList, Results).
 
-%First pass to convert MeTTa to Prolog Terms and register functions:
-parse_form(form(S), parsed(T, S, Term)) :- sread(S, Term),
-                                           ( Term = [=, [F|W], _], atom(F) -> register_fun(F), length(W, N), Arity is N + 1, assertz(arity(F,Arity)), T=function
-                                                                            ; T=expression ).
-parse_form(runnable(S), parsed(runnable, S, Term)) :- sread(S, Term).
+%First pass to convert MeTTa to Prolog Terms and register owned functions:
+parse_form(Space, form(S), parsed(T, S, Term)) :- sread(S, Term),
+                                                  ( Term = [=, [F|W], _], atom(F)
+                                                    -> register_space_fun(Space, F, Pred),
+                                                       length(W, N), Arity is N + 1,
+                                                       assertz(arity(Pred, Arity)), T=function
+                                                    ; T=expression ).
+parse_form(_, runnable(S), parsed(runnable, S, Term)) :- sread(S, Term).
 
 %Second pass to compile / run / add the Terms:
 process_form(Space, parsed(expression, _, Term), []) :- 'add-atom'(Space, Term, true),
                                                         ( silent(true) -> true ; swrite(Term,STerm),
                                                                                  format("\e[33m--> metta sexpr -->~n\e[36m~w~n", [STerm]),
                                                                                  format("\e[33m^^^^^^^^^^^^^^^^^^^~n\e[0m") ).
-process_form(_, parsed(runnable, FormStr, Term), Result) :- translate_expr([collapse, Term], Goals, Result),
+process_form(Space, parsed(runnable, FormStr, Term), Result) :- translate_expr_in_space(Space, [collapse, Term], Goals, Result),
                                                             ( silent(true) -> true ; format("\e[33m--> metta runnable  -->~n\e[36m!~w~n\e[33m-->  prolog goal  -->\e[35m ~n", [FormStr]),
                                                                                      forall(member(G, Goals), portray_clause((:- G))),
                                                                                      format("\e[33m^^^^^^^^^^^^^^^^^^^^^^^~n\e[0m") ),
                                                             call_goals(Goals).
 process_form(Space, parsed(function, FormStr, Term), []) :- add_sexp(Space, Term),
                                                             Term = [=, [F|_], _],
-                                                            translate_clause(Term, Clause),
-                                                            assertz(Clause, Ref),
-                                                            assertz(translated_from(Ref, Term)),
-                                                            metta_on_function_changed(F),
+                                                            install_function_clause(Space, Term, Ref),
+                                                            space_pred(Space, F, Pred),
+                                                            metta_on_function_changed(Pred),
                                                             ( silent(true) -> true ; format("\e[33m--> metta function -->~n\e[36m~w~n\e[33m--> prolog clause -->~n\e[32m", [FormStr]),
                                                                                      clause(Head, Body, Ref),
                                                                                      ( Body == true -> Show = Head; Show = (Head :- Body) ),

--- a/src/filereader.pl
+++ b/src/filereader.pl
@@ -14,7 +14,14 @@ process_metta_string(S, Results, Space) :- string_codes(S, Cs),
                                            strip(Cs, 0, Codes),
                                            phrase(top_forms(Forms, 1), Codes),
                                            maplist(parse_form, Forms, ParsedForms),
-                                           maplist(process_form(Space), ParsedForms, ResultsList), !,
+                                           findall(F-TypeChain,
+                                                   ( Space == '&self',
+                                                     member(parsed(expression, _, Term), ParsedForms),
+                                                     function_type_annotation_term(Term, F, TypeChain) ),
+                                                   PredeclaredTypes),
+                                           with_predeclared_function_types(
+                                               PredeclaredTypes,
+                                               maplist(process_form(Space), ParsedForms, ResultsList)), !,
                                            append(ResultsList, Results).
 
 %First pass to convert MeTTa to Prolog Terms and register functions:

--- a/src/metta.pl
+++ b/src/metta.pl
@@ -194,6 +194,25 @@ get_type_candidate(X, T) :- \+ get_function_type(X, _),
                             is_list(X),
                             maplist('get-type', X, T).
 get_type_candidate(X, T) :- match('&self', [':',X,T], T, _).
+
+'space-get-type'(Space, X, T) :-
+    ( space_get_type_candidate(Space, X, T) *-> true ; T = '%Undefined%' ).
+space_get_type_candidate(_, X, 'Number') :- number(X), !.
+space_get_type_candidate(_, X, _) :- var(X), !.
+space_get_type_candidate(_, X, 'String') :- string(X), !.
+space_get_type_candidate(_, true, 'Bool') :- !.
+space_get_type_candidate(_, false, 'Bool') :- !.
+space_get_type_candidate(Space, X, T) :- space_get_function_type(Space, X, T).
+space_get_type_candidate(Space, X, T) :-
+    \+ space_get_function_type(Space, X, _),
+    is_list(X),
+    maplist('space-get-type'(Space), X, T).
+space_get_type_candidate(Space, X, T) :- match(Space, [':',X,T], T, _).
+
+space_get_function_type(Space, [F|Args], T) :- nonvar(F),
+                                               match(Space, [':',F,[->|Types]], _, _),
+                                               append(ArgTypes, [T], Types),
+                                               maplist('space-get-type'(Space), Args, ArgTypes).
 'get-metatype'(X, 'Variable') :- var(X), !.
 'get-metatype'(X, 'Grounded') :- number(X), !.
 'get-metatype'(X, 'Grounded') :- string(X), !.
@@ -268,6 +287,9 @@ py_bool_norm(R, R).
 %%% Eval: %%%
 eval(C, Out) :- translate_expr(C, Goals, Out),
                 call_goals(Goals).
+
+eval(C, Space, Out) :- translate_expr_in_space(Space, C, Goals, Out),
+                       call_goals(Goals).
 
 call_goals([]).
 call_goals([G|Gs]) :- call(G), 

--- a/src/spaces.pl
+++ b/src/spaces.pl
@@ -7,50 +7,52 @@ remove_sexp(Space, [Rel|Args]) :- Term =.. [Space, Rel | Args],
                                   retractall(Term).
 
 %Arrow declarations alter the code emitted for stored functions.
-'add-atom'(Space, Term, true) :- Space == '&self',
+'add-atom'(Space, Term, true) :- atom(Space),
                                  function_type_annotation_term(Term, F, TypeChain), !,
-                                 ( predeclared_function_type_variant(F, TypeChain)
+                                 ( predeclared_function_type_variant(Space, F, TypeChain)
                                    -> add_sexp(Space, Term)
-                                   ;  revise_function_type(F, add_sexp(Space, Term)) ).
+                                   ; revise_function_type(Space, F, add_sexp(Space, Term)) ).
 
-%Add a function atom:
-'add-atom'(Space, Term, true) :- Term = [=,[FAtom|W],_], !,
+%Add a function atom to its owner's compiled program:
+'add-atom'(Space, Term, true) :- Term = [=,[FAtom|W],_], atom(Space), atom(FAtom), !,
                                  add_sexp(Space, Term),
-                                 register_fun(FAtom),
+                                 register_space_fun(Space, FAtom, Pred),
                                  length(W, N),
                                  Arity is N + 1,
-                                 assertz(arity(FAtom,Arity)),
-                                 once(translate_clause(Term, Clause)),
-                                 assertz(Clause, Ref),
-                                 assertz(translated_from(Ref, Term)),
-                                 metta_on_function_changed(FAtom),
-                                 invalidate_specializations(FAtom),
-                                 maybe_print_compiled_clause("added function", Term, Clause).
+                                 assertz(arity(Pred,Arity)),
+                                 install_function_clause(Space, Term, Ref),
+                                 metta_on_function_changed(Pred),
+                                 invalidate_specializations(Pred),
+                                 ( silent(true) -> true
+                                 ; clause(Head, Body, Ref),
+                                   maybe_print_compiled_clause("added function", Term, (Head :- Body)) ).
 
 %Add an atom to the space:
 'add-atom'(Space, Term, true) :- add_sexp(Space, Term).
 
-'remove-atom'(Space, Term, true) :- Space == '&self',
+'remove-atom'(Space, Term, true) :- atom(Space),
                                     function_type_annotation_term(Term, F, TypeChain), !,
                                     revise_function_type(
-                                        F,
-                                        ( retractall(predeclared_function_type(F, TypeChain)),
+                                        Space, F,
+                                        ( retractall(predeclared_function_type(Space, F, TypeChain)),
                                           remove_sexp(Space, Term) )).
 
 %%Remove a function atom:
-'remove-atom'(Space, Term, Removed) :- Term = [=,[F|Args],Body], !,
+'remove-atom'(Space, Term, Removed) :- Term = [=,[F|Args],Body],
+                                       atom(Space), atom(F), !,
                                        remove_sexp(Space, Term),
-                                       catch(nb_getval(F, Prev), _, Prev = []),
+                                       space_pred(Space, F, Pred),
+                                       catch(nb_getval(Pred, Prev), _, Prev = []),
                                        (   select(fun_meta(Args, Body), Prev, Rest)
-                                           -> ( Rest == [] -> nb_delete(F)
-                                                            ; nb_setval(F, Rest) ) ; true ),
-                                       findall(Ref, translated_from(Ref, Term), Refs),
-                                       forall(member(Ref, Refs), erase(Ref)),
-                                       retractall(translated_from(_, Term)),
-                                       metta_on_function_changed(F),
-                                       invalidate_specializations(F),
-                                       ( \+ ( current_predicate(F/A), functor(H2, F, A), clause(H2, _, _) )
-                                         -> retractall(fun(F)), metta_on_function_removed(F)
+                                           -> ( Rest == [] -> nb_delete(Pred)
+                                                            ; nb_setval(Pred, Rest) ) ; true ),
+                                       uninstall_function_clauses(Space, Term, Refs),
+                                       metta_on_function_changed(Pred),
+                                       invalidate_specializations(Pred),
+                                       ( \+ ( current_predicate(Pred/A), functor(H2, Pred, A), clause(H2, _, _) )
+                                         -> retractall(fun(Pred)),
+                                            retractall(space_fun(Space, F, Pred)),
+                                            metta_on_function_removed(Pred)
                                          ; true ),
                                        ( Refs = [] -> Removed = false ; Removed = true ).
 

--- a/src/spaces.pl
+++ b/src/spaces.pl
@@ -6,6 +6,13 @@ add_sexp(Space, [Rel|Args]) :- Term =.. [Space, Rel | Args],
 remove_sexp(Space, [Rel|Args]) :- Term =.. [Space, Rel | Args],
                                   retractall(Term).
 
+%Arrow declarations alter the code emitted for stored functions.
+'add-atom'(Space, Term, true) :- Space == '&self',
+                                 function_type_annotation_term(Term, F, TypeChain), !,
+                                 ( predeclared_function_type_variant(F, TypeChain)
+                                   -> add_sexp(Space, Term)
+                                   ;  revise_function_type(F, add_sexp(Space, Term)) ).
+
 %Add a function atom:
 'add-atom'(Space, Term, true) :- Term = [=,[FAtom|W],_], !,
                                  add_sexp(Space, Term),
@@ -22,6 +29,13 @@ remove_sexp(Space, [Rel|Args]) :- Term =.. [Space, Rel | Args],
 
 %Add an atom to the space:
 'add-atom'(Space, Term, true) :- add_sexp(Space, Term).
+
+'remove-atom'(Space, Term, true) :- Space == '&self',
+                                    function_type_annotation_term(Term, F, TypeChain), !,
+                                    revise_function_type(
+                                        F,
+                                        ( retractall(predeclared_function_type(F, TypeChain)),
+                                          remove_sexp(Space, Term) )).
 
 %%Remove a function atom:
 'remove-atom'(Space, Term, Removed) :- Term = [=,[F|Args],Body], !,

--- a/src/specializer.pl
+++ b/src/specializer.pl
@@ -7,6 +7,7 @@
 %higher-order argument, (= (evolve $r $g) (evolve (twice $r) $g)) - would otherwise diverge at compile time:
 maybe_specialize_call(HV, AVs, Out, Goal) :- catch(nb_getval('$spec_stack', Stack), _, Stack = []),
                                              \+ memberchk(HV, Stack),
+                                             \+ ( space_fun(Space, _, HV), Space \== '&self' ),
                                              setup_call_cleanup( (catch(nb_getval(specneeded,Prev),_,Prev = []), nb_setval(specneeded,false),
                                                                   nb_setval('$spec_stack', [HV|Stack])),
                                                                  specialize_call(HV, AVs, Out, Goal),
@@ -57,7 +58,7 @@ specialize_call(HV, AVs, Out, Goal) :- %1. Retrieve a copy of all meta-clauses s
                                                %4.5 Assert and print each of the created specializations:
                                                forall(member(clause_info(Input, Clause), ClauseInfos),
                                                ( asserta(Clause, Ref),
-                                                 assertz(translated_from(Ref, Input)),
+                                                 assertz(translated_from(Ref, '&self', Input)),
                                                  add_sexp('&self', Input),
                                                  format(atom(Label), "metta specialization (~w)", [SpecName]),
                                                  maybe_print_compiled_clause(Label, Input, Clause) ))
@@ -112,9 +113,11 @@ forget_symbol(Name) :- retractall('&self'(=, [Name|_], _)),
                        retractall('&self'(:, Name, _)),
                        findall(Ref, ( current_predicate(Name/A), functor(H, Name, A), clause(H, _, Ref) ), Refs),
                        forall(member(R, Refs), erase(R)),
+                       forget_function_provenance(Name),
                        metta_on_function_removed(Name),
                        retractall(arity(Name,_)),
                        retractall(fun(Name)),
+                       retractall(space_fun(_, _, Name)),
                        catch(nb_delete(Name), _, true),
                        retractall(ho_specialization(Name,_)).
 

--- a/src/specializer.pl
+++ b/src/specializer.pl
@@ -47,7 +47,7 @@ specialize_call(HV, AVs, Out, Goal) :- %1. Retrieve a copy of all meta-clauses s
                                              assertz(ho_specialization(HV, SpecName)),
                                              assertz(arity(SpecName, Arity)),
                                              ( %4.2. Re-use the type definition of the parent function for the specialization:
-                                               findall(TypeChain, catch(match('&self', [':', HV, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
+                                               function_type_chains(HV, TypeChains),
                                                forall(member(TypeChain, TypeChains), add_sexp('&self', [':', SpecName, TypeChain])),
                                                %4.3 Translate specialized MeTTa clauseses to Prolog, keeping track of the function we are compiling through recursion:
                                                maplist({SpecName}/[fun_meta(ArgsNorm,BodyExpr),clause_info(Input,Clause)]>>

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -39,6 +39,195 @@ translate_clause(Input, (Head :- BodyConj), ConstrainArgs) :-
                                                append(GoalsPrefix, FinalGoals, Goals),
                                                goals_list_to_conj(Goals, BodyConj).
 
+%%% Coherent function-type revisions %%%
+
+:- dynamic translated_from/2.
+:- thread_local predeclared_function_type/2.
+
+function_type_annotation_term([':', F, TypeChain], F, TypeChain) :-
+    atom(F),
+    TypeChain = ['->'|Types],
+    Types \= [].
+
+with_predeclared_function_types(Types, Goal) :-
+    setup_call_cleanup(
+        maplist(assert_predeclared_function_type, Types, Refs),
+        Goal,
+        maplist(erase_predeclared_function_type, Refs)).
+
+assert_predeclared_function_type(F-TypeChain, Ref) :-
+    assertz(predeclared_function_type(F, TypeChain), Ref).
+
+erase_predeclared_function_type(Ref) :- catch(erase(Ref), _, true).
+
+predeclared_function_type_variant(F, TypeChain) :-
+    predeclared_function_type(F, Existing),
+    TypeChain =@= Existing, !.
+
+function_type_chains(F, TypeChains) :-
+    findall(TypeChain,
+            catch(match('&self', [':', F, TypeChain], TypeChain, TypeChain),
+                  _, fail),
+            Live),
+    findall(TypeChain, predeclared_function_type(F, TypeChain), Predeclared),
+    append(Live, Predeclared, All),
+    variant_unique(All, TypeChains).
+
+variant_unique(Items, Unique) :- variant_unique(Items, [], Unique).
+
+variant_unique([], _, []).
+variant_unique([Item|Items], Seen, Unique) :-
+    member_variant(Item, Seen), !,
+    variant_unique(Items, Seen, Unique).
+variant_unique([Item|Items], Seen, [Item|Unique]) :-
+    variant_unique(Items, [Item|Seen], Unique).
+
+member_variant(Item, [Seen|_]) :- Item =@= Seen, !.
+member_variant(Item, [_|Seen]) :- member_variant(Item, Seen).
+
+% The compiled clause is the authority for which source definition is live.
+function_source_clauses(F, Clauses) :-
+    findall(Ref-Term,
+            ( translated_from(Ref, Term),
+              clause(_, _, Ref),
+              Term = [=, [SourceF|_], _],
+              SourceF == F,
+              \+ ho_specialization(_, F) ),
+            Clauses).
+
+source_mentions_atom(Term, Atom) :-
+    atom(Term), !,
+    Term == Atom.
+source_mentions_atom(Term, Atom) :-
+    nonvar(Term),
+    is_list(Term),
+    member(Part, Term),
+    source_mentions_atom(Part, Atom).
+
+direct_source_dependents(Callee, Functions) :-
+    findall(F,
+            ( translated_from(Ref, Term),
+              clause(_, _, Ref),
+              Term = [=, [F|_], _],
+              atom(F),
+              \+ ho_specialization(_, F),
+              source_mentions_atom(Term, Callee) ),
+            Functions0),
+    sort(Functions0, Functions).
+
+source_dependent_closure(Callee, Functions) :-
+    source_dependent_closure([Callee], [], [], Functions0),
+    sort(Functions0, Functions).
+
+source_dependent_closure([], _, Functions, Functions).
+source_dependent_closure([Current|Pending], Seen, Acc, Functions) :-
+    memberchk(Current, Seen), !,
+    source_dependent_closure(Pending, Seen, Acc, Functions).
+source_dependent_closure([Current|Pending], Seen, Acc, Functions) :-
+    direct_source_dependents(Current, Direct),
+    append(Pending, Direct, Next),
+    append(Direct, Acc, NextAcc),
+    source_dependent_closure(Next, [Current|Seen], NextAcc, Functions).
+
+function_metadata(F, present(Metadata)) :-
+    catch(nb_getval(F, Metadata), _, fail), !.
+function_metadata(_, absent).
+
+restore_function_metadata(F, present(Metadata)) :- !,
+    nb_setval(F, Metadata).
+restore_function_metadata(F, absent) :-
+    catch(nb_delete(F), _, true).
+
+snapshot_function_metadata([], []).
+snapshot_function_metadata([F|Functions], [F-State|States]) :-
+    function_metadata(F, State),
+    snapshot_function_metadata(Functions, States).
+
+restore_function_metadata_snapshot([]).
+restore_function_metadata_snapshot([F-State|States]) :-
+    restore_function_metadata(F, State),
+    restore_function_metadata_snapshot(States).
+
+type_revision_plan(Callee, Plan, MetadataSnapshot) :-
+    source_dependent_closure(Callee, Functions),
+    maplist(function_recompile_entry, Functions, Plan),
+    ( Plan == []
+      -> MetadataSnapshot = []
+      ;  findall(Specialization, ho_specialization(_, Specialization), Specs0),
+         append(Functions, Specs0, Symbols0),
+         sort(Symbols0, Symbols),
+         snapshot_function_metadata(Symbols, MetadataSnapshot) ).
+
+function_recompile_entry(F, function(F, Clauses)) :-
+    function_source_clauses(F, Clauses).
+
+erase_compiled_clauses([]).
+erase_compiled_clauses([Ref-_|Clauses]) :-
+    erase(Ref),
+    retractall(translated_from(Ref, _)),
+    erase_compiled_clauses(Clauses).
+
+compile_source_clauses([], _).
+compile_source_clauses([_-Term|Clauses], F) :-
+    copy_term(Term, Fresh),
+    once(translate_clause(Fresh, Clause)),
+    assertz(Clause, Ref),
+    assertz(translated_from(Ref, Fresh)),
+    compile_source_clauses(Clauses, F).
+
+recompile_function(function(F, Clauses)) :-
+    erase_compiled_clauses(Clauses),
+    nb_setval(F, []),
+    compile_source_clauses(Clauses, F),
+    metta_on_function_changed(F).
+
+specialization_stack(Stack) :-
+    catch(nb_getval('$spec_stack', Stack), _, Stack = []).
+
+with_specialization_suppressed(Goal) :-
+    specialization_stack(Prior),
+    findall(F, fun(F), Functions0),
+    sort(Functions0, Functions),
+    setup_call_cleanup(nb_setval('$spec_stack', Functions),
+                       Goal,
+                       nb_setval('$spec_stack', Prior)).
+
+invalidate_all_specializations :-
+    findall(F, ho_specialization(F, _), Functions0),
+    sort(Functions0, Functions),
+    forall(member(F, Functions), invalidate_specializations(F)).
+
+apply_type_revision([]).
+apply_type_revision(Plan) :-
+    Plan \= [],
+    with_specialization_suppressed(
+        ( invalidate_all_specializations,
+          maplist(recompile_function, Plan) )).
+
+restore_type_revision_state(state(snapshot(MetadataSnapshot))) :- !,
+    restore_function_metadata_snapshot(MetadataSnapshot).
+restore_type_revision_state(_).
+
+% Type mutation and dependent recompilation are one database transaction.
+% Non-backtrackable compiler metadata is restored explicitly on failure.
+revise_function_type(F, Mutation) :-
+    with_mutex(petta_type_revision,
+        ( State = state(none),
+          catch(
+              ( transaction(
+                    ( function_type_chains(F, Before),
+                      call(Mutation),
+                      function_type_chains(F, After),
+                      ( Before =@= After -> true
+                      ; type_revision_plan(F, Plan, MetadataSnapshot),
+                        nb_setarg(1, State, snapshot(MetadataSnapshot)),
+                        apply_type_revision(Plan) ) ))
+                -> true
+                ;  restore_type_revision_state(State), fail ),
+              Error,
+              ( restore_type_revision_state(State),
+                throw(Error) )) )).
+
 %Print compiled clause:
 maybe_print_compiled_clause(_, _, _) :- silent(true), !.
 maybe_print_compiled_clause(Label, FormTerm, Clause) :-
@@ -120,7 +309,7 @@ translate_expr([H0|T0], Goals, Out) :-
         safe_rewrite_streamops([H0|T0],[H|T]),
         translate_expr(H, GsH, HV),
         %--- Translator rules ---:
-        ( nonvar(HV), translator_rule(HV) -> ( catch(match('&self', [':', HV, TypeChain], TypeChain, TypeChain), _, fail)
+        ( nonvar(HV), translator_rule(HV) -> ( function_type_chains(HV, [TypeChain|_])
                                                -> TypeChain = [->|Xs],
                                                   append(ArgTypes, [_], Xs),
                                                   translate_args_by_type(T, ArgTypes, GsT, T1)
@@ -337,8 +526,7 @@ translate_expr([H0|T0], Goals, Out) :-
             ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
             ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
             ) % Check for type definition [:,HV,TypeChain]
-            -> findall(TypeChain, catch(match('&self', [':', Fun, TypeChain], TypeChain, TypeChain), _, fail), TypeChains),
-               list_to_set(TypeChains, UniqueTypeChains),
+            -> function_type_chains(Fun, UniqueTypeChains),
                ( UniqueTypeChains \= []
                  -> length(AllAVs, InputArity),
                     Arity is InputArity + 1,
@@ -469,7 +657,8 @@ next_lambda_name(Name) :- ( catch(nb_getval(lambda_counter, Prev), _, Prev = 0) 
 
 declared_output_type(F, OutType) :- atom(F),
 									nonvar(OutType),
-									catch(match('&self', [':', F, TypeChain], TypeChain, TypeChain), _, fail),
+									function_type_chains(F, TypeChains),
+									member(TypeChain, TypeChains),
 									TypeChain = [->|Types],
 									append(_, [DeclaredOutType], Types),
 									DeclaredOutType == OutType.

--- a/src/translator.pl
+++ b/src/translator.pl
@@ -7,7 +7,7 @@ constrain_args([F, A, B], Out, Goals) :- nonvar(F),
                                          Out = [A1|B1],
                                          append(G1, G2, Goals), !.
 constrain_args([F|Args], Var, Goals) :- atom(F),
-                                        fun(F), !,
+                                        callable_fun(F, _), !,
                                         translate_expr([F|Args], GoalsExpr, Var),
                                         flatten(GoalsExpr, Goals).
 constrain_args(In, Out, Goals) :- maplist(constrain_args, In, Out, NestedGoalsList),
@@ -17,11 +17,13 @@ constrain_args(In, Out, Goals) :- maplist(constrain_args, In, Out, NestedGoalsLi
 translate_clause(Input, (Head :- BodyConj)) :- translate_clause(Input, (Head :- BodyConj), true).
 translate_clause(Input, (Head :- BodyConj), ConstrainArgs) :-
                                                Input = [=, [F|Args0], BodyExpr],
+                                               current_translation_space(Space),
+                                               space_pred(Space, F, Pred),
                                                ( ConstrainArgs -> maplist(constrain_args, Args0, Args1, GoalsA),
                                                                   flatten(GoalsA,GoalsPrefix)
                                                                 ; Args1 = Args0, GoalsPrefix = [] ),
-                                               catch(nb_getval(F, Prev), _, Prev = []),
-                                               nb_setval(F, [fun_meta(Args1, BodyExpr) | Prev]),
+                                               catch(nb_getval(Pred, Prev), _, Prev = []),
+                                               nb_setval(Pred, [fun_meta(Args1, BodyExpr) | Prev]),
                                                ( declared_output_type(F, 'Atom')
                                                  -> GoalsBody = [],
                                                     ExpOut = BodyExpr
@@ -33,43 +35,123 @@ translate_clause(Input, (Head :- BodyConj), ConstrainArgs) :-
                                                   append(GoalsBody,[Goal],FinalGoals), append(Args1,ExtraArgs,HeadArgs)
                                                ; FinalGoals= GoalsBody , HeadArgs = Args1, Out = ExpOut ),
                                                append(HeadArgs, [Out], FinalArgs),
-                                               Head =.. [F|FinalArgs],
+                                               Head =.. [Pred|FinalArgs],
                                                length(FinalArgs, CompiledArity),
-                                               (arity(F, CompiledArity) -> true ; assertz(arity(F, CompiledArity))),
+                                               (arity(Pred, CompiledArity) -> true ; assertz(arity(Pred, CompiledArity))),
                                                append(GoalsPrefix, FinalGoals, Goals),
                                                goals_list_to_conj(Goals, BodyConj).
 
+%%% Executable space ownership %%%
+
+:- dynamic space_fun/3.
+:- dynamic translated_from/3.
+
+% Existing compiler clients operate on the default program only.
+translated_from(Ref, Term) :- translated_from(Ref, '&self', Term).
+
+current_translation_space(Space) :-
+    ( nb_current('$translation_space', Current) -> Space = Current
+    ; Space = '&self' ).
+
+with_translation_space(Space, Goal) :-
+    current_translation_space(Previous),
+    ( Previous == Space -> call(Goal)
+    ; setup_call_cleanup(nb_setval('$translation_space', Space),
+                         Goal,
+                         nb_setval('$translation_space', Previous)) ).
+
+translate_expr_in_space(Space, Input, Goals, Out) :-
+    with_translation_space(Space, translate_expr(Input, Goals, Out)).
+
+space_pred('&self', F, F) :- !.
+space_pred(Space, F, Pred) :-
+    atom_length(Space, SpaceLength),
+    atom_length(F, FunctionLength),
+    atomic_list_concat(['$petta_space$', SpaceLength, '$', Space,
+                        '$', FunctionLength, '$', F], Pred).
+
+register_space_fun(Space, F, Pred) :-
+    space_pred(Space, F, Pred),
+    ( space_fun(Space, F, Pred) -> true
+    ; assertz(space_fun(Space, F, Pred)) ),
+    register_fun(Pred).
+
+space_call_target(Space, F, Pred) :-
+    ( space_fun(Space, F, Owned) -> Pred = Owned
+    ; Space == '&self' -> fun(F), Pred = F
+    ; fun(F), \+ space_fun('&self', F, _) -> Pred = F
+    ).
+
+callable_fun(F, Pred) :-
+    current_translation_space(Space),
+    space_call_target(Space, F, Pred).
+
+reduce_goal(Term, Out, Goal) :-
+    current_translation_space(Space),
+    ( Space == '&self' -> Goal = reduce(Term, Out)
+    ; Goal = space_reduce(Space, Term, Out) ).
+
+type_guard_goal(Value, Type, Guard) :-
+    current_translation_space(Space),
+    ( Space == '&self'
+      -> Guard = ('get-type'(Value, Type) *-> true ; 'get-metatype'(Value, Type))
+    ; Guard = ('space-get-type'(Space, Value, Type) *-> true ; 'get-metatype'(Value, Type)) ).
+
+pred_type_chains(Pred, TypeChains) :-
+    ( space_fun(Space, F, Pred) -> function_type_chains(Space, F, TypeChains)
+    ; function_type_chains(Pred, TypeChains) ).
+
+install_function_clause(Space, Term, Ref) :-
+    with_translation_space(Space, once(translate_clause(Term, Clause))),
+    assertz(Clause, Ref),
+    assertz(translated_from(Ref, Space, Term)).
+
+uninstall_function_clauses(Space, Term, Refs) :-
+    findall(Ref, translated_from(Ref, Space, Term), Refs),
+    forall(member(Ref, Refs), erase(Ref)),
+    retractall(translated_from(_, Space, Term)).
+
+forget_function_provenance(Pred) :-
+    findall(Ref,
+            ( translated_from(Ref, Space, [=, [F|_], _]),
+              space_pred(Space, F, Pred) ),
+            Refs),
+    forall(member(Ref, Refs), retractall(translated_from(Ref, _, _))).
+
 %%% Coherent function-type revisions %%%
 
-:- dynamic translated_from/2.
-:- thread_local predeclared_function_type/2.
+:- thread_local predeclared_function_type/3.
 
 function_type_annotation_term([':', F, TypeChain], F, TypeChain) :-
     atom(F),
     TypeChain = ['->'|Types],
     Types \= [].
 
-with_predeclared_function_types(Types, Goal) :-
+with_predeclared_function_types(Space, Types, Goal) :-
     setup_call_cleanup(
-        maplist(assert_predeclared_function_type, Types, Refs),
+        maplist(assert_predeclared_function_type(Space), Types, Refs),
         Goal,
         maplist(erase_predeclared_function_type, Refs)).
 
-assert_predeclared_function_type(F-TypeChain, Ref) :-
-    assertz(predeclared_function_type(F, TypeChain), Ref).
+assert_predeclared_function_type(Space, F-TypeChain, Ref) :-
+    assertz(predeclared_function_type(Space, F, TypeChain), Ref).
 
 erase_predeclared_function_type(Ref) :- catch(erase(Ref), _, true).
 
-predeclared_function_type_variant(F, TypeChain) :-
-    predeclared_function_type(F, Existing),
+predeclared_function_type_variant(Space, F, TypeChain) :-
+    predeclared_function_type(Space, F, Existing),
     TypeChain =@= Existing, !.
 
 function_type_chains(F, TypeChains) :-
+    current_translation_space(Space),
+    function_type_chains(Space, F, TypeChains).
+
+function_type_chains(Space, F, TypeChains) :-
     findall(TypeChain,
-            catch(match('&self', [':', F, TypeChain], TypeChain, TypeChain),
+            catch(match(Space, [':', F, TypeChain], TypeChain, TypeChain),
                   _, fail),
             Live),
-    findall(TypeChain, predeclared_function_type(F, TypeChain), Predeclared),
+    findall(TypeChain, predeclared_function_type(Space, F, TypeChain), Predeclared),
     append(Live, Predeclared, All),
     variant_unique(All, TypeChains).
 
@@ -86,9 +168,9 @@ member_variant(Item, [Seen|_]) :- Item =@= Seen, !.
 member_variant(Item, [_|Seen]) :- member_variant(Item, Seen).
 
 % The compiled clause is the authority for which source definition is live.
-function_source_clauses(F, Clauses) :-
+function_source_clauses(Space, F, Clauses) :-
     findall(Ref-Term,
-            ( translated_from(Ref, Term),
+            ( translated_from(Ref, Space, Term),
               clause(_, _, Ref),
               Term = [=, [SourceF|_], _],
               SourceF == F,
@@ -104,9 +186,9 @@ source_mentions_atom(Term, Atom) :-
     member(Part, Term),
     source_mentions_atom(Part, Atom).
 
-direct_source_dependents(Callee, Functions) :-
+direct_source_dependents(Space, Callee, Functions) :-
     findall(F,
-            ( translated_from(Ref, Term),
+            ( translated_from(Ref, Space, Term),
               clause(_, _, Ref),
               Term = [=, [F|_], _],
               atom(F),
@@ -115,19 +197,19 @@ direct_source_dependents(Callee, Functions) :-
             Functions0),
     sort(Functions0, Functions).
 
-source_dependent_closure(Callee, Functions) :-
-    source_dependent_closure([Callee], [], [], Functions0),
+source_dependent_closure(Space, Callee, Functions) :-
+    source_dependent_closure(Space, [Callee], [], [], Functions0),
     sort(Functions0, Functions).
 
-source_dependent_closure([], _, Functions, Functions).
-source_dependent_closure([Current|Pending], Seen, Acc, Functions) :-
+source_dependent_closure(_, [], _, Functions, Functions).
+source_dependent_closure(Space, [Current|Pending], Seen, Acc, Functions) :-
     memberchk(Current, Seen), !,
-    source_dependent_closure(Pending, Seen, Acc, Functions).
-source_dependent_closure([Current|Pending], Seen, Acc, Functions) :-
-    direct_source_dependents(Current, Direct),
+    source_dependent_closure(Space, Pending, Seen, Acc, Functions).
+source_dependent_closure(Space, [Current|Pending], Seen, Acc, Functions) :-
+    direct_source_dependents(Space, Current, Direct),
     append(Pending, Direct, Next),
     append(Direct, Acc, NextAcc),
-    source_dependent_closure(Next, [Current|Seen], NextAcc, Functions).
+    source_dependent_closure(Space, Next, [Current|Seen], NextAcc, Functions).
 
 function_metadata(F, present(Metadata)) :-
     catch(nb_getval(F, Metadata), _, fail), !.
@@ -148,38 +230,40 @@ restore_function_metadata_snapshot([F-State|States]) :-
     restore_function_metadata(F, State),
     restore_function_metadata_snapshot(States).
 
-type_revision_plan(Callee, Plan, MetadataSnapshot) :-
-    source_dependent_closure(Callee, Functions),
-    maplist(function_recompile_entry, Functions, Plan),
+type_revision_plan(Space, Callee, Plan, MetadataSnapshot) :-
+    source_dependent_closure(Space, Callee, Functions),
+    maplist(function_recompile_entry(Space), Functions, Plan),
     ( Plan == []
       -> MetadataSnapshot = []
-      ;  findall(Specialization, ho_specialization(_, Specialization), Specs0),
-         append(Functions, Specs0, Symbols0),
+      ;  maplist(space_pred(Space), Functions, Predicates),
+         ( Space == '&self'
+           -> findall(Specialization, ho_specialization(_, Specialization), Specs)
+           ; Specs = [] ),
+         append(Predicates, Specs, Symbols0),
          sort(Symbols0, Symbols),
          snapshot_function_metadata(Symbols, MetadataSnapshot) ).
 
-function_recompile_entry(F, function(F, Clauses)) :-
-    function_source_clauses(F, Clauses).
+function_recompile_entry(Space, F, function(Space, F, Pred, Clauses)) :-
+    space_pred(Space, F, Pred),
+    function_source_clauses(Space, F, Clauses).
 
 erase_compiled_clauses([]).
 erase_compiled_clauses([Ref-_|Clauses]) :-
     erase(Ref),
-    retractall(translated_from(Ref, _)),
+    retractall(translated_from(Ref, _, _)),
     erase_compiled_clauses(Clauses).
 
 compile_source_clauses([], _).
-compile_source_clauses([_-Term|Clauses], F) :-
+compile_source_clauses([_-Term|Clauses], Space) :-
     copy_term(Term, Fresh),
-    once(translate_clause(Fresh, Clause)),
-    assertz(Clause, Ref),
-    assertz(translated_from(Ref, Fresh)),
-    compile_source_clauses(Clauses, F).
+    install_function_clause(Space, Fresh, _),
+    compile_source_clauses(Clauses, Space).
 
-recompile_function(function(F, Clauses)) :-
+recompile_function(function(Space, _F, Pred, Clauses)) :-
     erase_compiled_clauses(Clauses),
-    nb_setval(F, []),
-    compile_source_clauses(Clauses, F),
-    metta_on_function_changed(F).
+    nb_setval(Pred, []),
+    compile_source_clauses(Clauses, Space),
+    metta_on_function_changed(Pred).
 
 specialization_stack(Stack) :-
     catch(nb_getval('$spec_stack', Stack), _, Stack = []).
@@ -197,11 +281,11 @@ invalidate_all_specializations :-
     sort(Functions0, Functions),
     forall(member(F, Functions), invalidate_specializations(F)).
 
-apply_type_revision([]).
-apply_type_revision(Plan) :-
+apply_type_revision(_, []).
+apply_type_revision(Space, Plan) :-
     Plan \= [],
     with_specialization_suppressed(
-        ( invalidate_all_specializations,
+        ( ( Space == '&self' -> invalidate_all_specializations ; true ),
           maplist(recompile_function, Plan) )).
 
 restore_type_revision_state(state(snapshot(MetadataSnapshot))) :- !,
@@ -210,18 +294,18 @@ restore_type_revision_state(_).
 
 % Type mutation and dependent recompilation are one database transaction.
 % Non-backtrackable compiler metadata is restored explicitly on failure.
-revise_function_type(F, Mutation) :-
+revise_function_type(Space, F, Mutation) :-
     with_mutex(petta_type_revision,
         ( State = state(none),
           catch(
               ( transaction(
-                    ( function_type_chains(F, Before),
+                    ( function_type_chains(Space, F, Before),
                       call(Mutation),
-                      function_type_chains(F, After),
+                      function_type_chains(Space, F, After),
                       ( Before =@= After -> true
-                      ; type_revision_plan(F, Plan, MetadataSnapshot),
+                      ; type_revision_plan(Space, F, Plan, MetadataSnapshot),
                         nb_setarg(1, State, snapshot(MetadataSnapshot)),
-                        apply_type_revision(Plan) ) ))
+                        apply_type_revision(Space, Plan) ) ))
                 -> true
                 ;  restore_type_revision_state(State), fail ),
               Error,
@@ -274,8 +358,27 @@ reduce([F|Args], Out) :- nonvar(F), atom(F), fun(F)
                             Out = [F|Args],
                             \+ cyclic_term(Out).
 
+% Named-space dynamic dispatch receives its owner as a compiled constant.
+space_reduce(Space, [F|Args], Out) :-
+        nonvar(F), atom(F), space_call_target(Space, F, Pred)
+        -> length(Args, N),
+           Arity is N + 1,
+           ( current_predicate(Pred/Arity), \+ (current_op(_, _, Pred), Arity =< 2)
+             -> resolve_memoization(Pred, Args, Out, Goal),
+                catch(call(Goal), _, fail)
+           ; incomplete_application_kind(Pred, Arity, partial)
+             -> Out = partial(Pred, Args)
+           ; throw_function_overapplication(Pred, N) )
+         ; compound(F), F = partial(Base, Bound)
+           -> append(Bound, Args, NewArgs),
+              space_reduce(Space, [Base|NewArgs], Out)
+         ; Out = [F|Args],
+           \+ cyclic_term(Out).
+
 %Calling reduce from aggregate function foldall needs this argument wrapping
 agg_reduce(AF, Acc, Val, NewAcc) :- reduce([AF, Acc, Val], NewAcc).
+space_agg_reduce(Space, AF, Acc, Val, NewAcc) :-
+    space_reduce(Space, [AF, Acc, Val], NewAcc).
 
 %Combined expr translation to goals list
 translate_expr_to_conj(Input, Conj, Out) :- translate_expr(Input, Goals, Out),
@@ -343,7 +446,11 @@ translate_expr([H0|T0], Goals, Out) :-
                   append(GsH, [concurrent_and(member((Goal,Res), Branches), (call(Goal), Out = Res))], Goals)
                ; translate_expr(L, GsL, LV),
                  append(GsH, GsL, Inner),
-                 append(Inner, [hyperpose_runtime(LV, Out)], Goals) )
+                 current_translation_space(HyperposeSpace),
+                 ( HyperposeSpace == '&self'
+                   -> HyperposeGoal = hyperpose_runtime(LV, Out)
+                   ; HyperposeGoal = space_hyperpose_runtime(HyperposeSpace, LV, Out) ),
+                 append(Inner, [HyperposeGoal], Goals) )
         ; HV == with_mutex, T = [M,X] -> translate_expr_to_conj(X, Conj, Out),
                                          append(GsH, [with_mutex(M,Conj)], Goals)
         ; HV == transaction, T = [X] -> translate_expr_to_conj(X, Conj, Out),
@@ -413,9 +520,11 @@ translate_expr([H0|T0], Goals, Out) :-
              translate_expr(TF, GsTF, TFHV),
              TestList = [TFHV, V],
              goals_list_to_conj(GsGF, GPre),
-             GenGoal = (GPre, reduce(GenList, V)),
+             reduce_goal(GenList, V, GenReduce),
+             GenGoal = (GPre, GenReduce),
+             reduce_goal(TestList, Truth, TestReduce),
              append(GsH, GsTF, Tmp0),
-             append(Tmp0, [( forall(GenGoal, ( reduce(TestList, Truth), Truth == true )) -> Out = true ; Out = false )], Goals)
+             append(Tmp0, [( forall(GenGoal, ( TestReduce, Truth == true )) -> Out = true ; Out = false )], Goals)
         ; HV == 'foldall', T = [AF, GF, InitS]
           -> translate_expr_to_conj(InitS, ConjInit, Init),
              translate_expr(AF, GsAF, AFV),
@@ -431,7 +540,11 @@ translate_expr([H0|T0], Goals, Out) :-
                               GenList = [GFHV] ),
              append(GsH, GsAF, Tmp1),
              append(Tmp1, GsGF, Tmp2),
-             append(Tmp2, [ConjInit, foldall(agg_reduce(AFV, V), reduce(GenList, V), Init, Out)], Goals)
+             reduce_goal(GenList, V, FoldReduce),
+             current_translation_space(FoldSpace),
+             ( FoldSpace == '&self' -> AggGoal = agg_reduce(AFV, V)
+             ; AggGoal = space_agg_reduce(FoldSpace, AFV, V) ),
+             append(Tmp2, [ConjInit, foldall(AggGoal, FoldReduce, Init, Out)], Goals)
         %--- Higher-order functions with pseudo-lambdas and lambdas ---:
         ; HV == 'foldl-atom', T = [List, Init, AccVar, XVar, Body]
           -> translate_expr_to_conj(List, ConjList, L),
@@ -460,16 +573,18 @@ translate_expr([H0|T0], Goals, Out) :-
                                            append(FreeVars, Args, FullArgs),
                                            % compile clause with all bound + free vars
                                            translate_clause([=, [F|FullArgs], Body], Clause),
-                                           register_fun(F),
+                                           current_translation_space(LambdaSpace),
+                                           space_pred(LambdaSpace, F, LambdaPred),
+                                           register_fun(LambdaPred),
                                            assertz(Clause),
-                                           format(atom(Label), "metta lambda (~w)", [F]),
+                                           format(atom(Label), "metta lambda (~w)", [LambdaPred]),
                                            maybe_print_compiled_clause(Label, ['|->', Args, Body], Clause),
                                            length(FullArgs, N),
                                            Arity is N + 1,
-                                           (arity(F, Arity) -> true ; assertz(arity(F, Arity))),
+                                           (arity(LambdaPred, Arity) -> true ; assertz(arity(LambdaPred, Arity))),
                                            % emit closure capturing the environment (free vars)
-                                           ( FreeVars == [] -> Out = F
-                                                             ; Out = partial(F, FreeVars) )
+                                           ( FreeVars == [] -> Out = LambdaPred
+                                                             ; Out = partial(LambdaPred, FreeVars) )
         %--- Spaces ---:
         ; ( HV == 'add-atom' ; HV == 'remove-atom' ), T = [Space,Atom] ->
                                                                    translate_expr(Space, G1, S),
@@ -495,16 +610,30 @@ translate_expr([H0|T0], Goals, Out) :-
                                      append(Inner, [Goal], Goals)
         %Produce a dynamic dispatch, translating Args for nesting:
         ; HV == reduce, T = [Expr] -> ( var(Expr) -> translate_expr(Expr, GsH, ExprOut),
-                                                     Goals = [reduce(ExprOut, Out)|GsH]
+                                                     reduce_goal(ExprOut, Out, ReduceGoal),
+                                                     Goals = [ReduceGoal|GsH]
                                                    ; Expr = [F|Args],
                                                      translate_args(Args, GsArgs, ArgsOut),
                                                      append(GsH, GsArgs, Inner),
                                                      ExprOut = [F|ArgsOut],
-                                                     append(Inner, [reduce(ExprOut, Out)], Goals) )
+                                                     reduce_goal(ExprOut, Out, ReduceGoal),
+                                                     append(Inner, [ReduceGoal], Goals) )
         %Invoke translator to evaluate MeTTa code as data/list:
         ; HV == eval, T = [Arg] -> append(GsH, [], Inner),
-                                   Goal = eval(Arg, Out),
+                                   current_translation_space(EvalSpace),
+                                   ( EvalSpace == '&self' -> Goal = eval(Arg, Out)
+                                   ; Goal = eval(Arg, EvalSpace, Out) ),
                                    append(Inner, [Goal], Goals)
+        %Evaluate within an explicitly selected space:
+        ; HV == eval, T = [Arg, SpaceExpr] -> translate_expr(SpaceExpr, GsS, Space),
+                                              append(GsH, GsS, Inner),
+                                              append(Inner, [eval(Arg, Space, Out)], Goals)
+        %A named-space type query stays with its compiled owner:
+        ; HV == 'get-type', T = [Arg],
+          current_translation_space(TypeSpace), TypeSpace \== '&self'
+          -> translate_expr(Arg, GsArg, Value),
+             append(GsH, GsArg, Inner),
+             append(Inner, ['space-get-type'(TypeSpace, Value, Out)], Goals)
         %Force arg to remain data/list:
         ; HV == quote, T = [Expr] -> append(GsH, [], Inner),
                                      Out = Expr,
@@ -522,11 +651,11 @@ translate_expr([H0|T0], Goals, Out) :-
         ; translate_args(T, GsT, AVs),
           append(GsH, GsT, Inner),
           %Known function => direct call:
-          ( is_list(AVs), 
-            ( atom(HV), fun(HV), Fun = HV, AllAVs = AVs, IsPartial = false
+          ( is_list(AVs),
+            ( atom(HV), callable_fun(HV, Fun), AllAVs = AVs, IsPartial = false
             ; compound(HV), HV = partial(Fun, Bound), append(Bound,AVs,AllAVs), IsPartial = true
             ) % Check for type definition [:,HV,TypeChain]
-            -> function_type_chains(Fun, UniqueTypeChains),
+            -> pred_type_chains(Fun, UniqueTypeChains),
                ( UniqueTypeChains \= []
                  -> length(AllAVs, InputArity),
                     Arity is InputArity + 1,
@@ -538,14 +667,15 @@ translate_expr([H0|T0], Goals, Out) :-
                          Goals = [Disj] )
               ; build_call_or_partial(Fun, AllAVs, Out, Inner, [], Goals))
           %Literals (numbers, strings, etc.), known non-function atom => data:
-          ; ( atomic(HV), \+ atom(HV) ; atom(HV), \+ fun(HV) ) -> Out = [HV|AVs],
-                                                                  Goals = Inner
+          ; ( atomic(HV), \+ atom(HV) ; atom(HV), \+ callable_fun(HV, _) ) -> Out = [HV|AVs],
+                                                                                       Goals = Inner
           %Plain data list: evaluate inner fun-sublists
           ; is_list(HV) -> eval_data_term(HV, Gd, HV1),
                            append(Inner, Gd, Goals),
                            Out = [HV1|AVs]
           %Unknown head (var/compound) => runtime dispatch:
-          ; append(Inner, [reduce([HV|AVs], Out)], Goals) )).
+          ; reduce_goal([HV|AVs], Out, ReduceGoal),
+            append(Inner, [ReduceGoal], Goals) )).
 
 %Generate actual function call or partial if arity not complete:
 build_call_or_partial(Fun, AVs, Out, Inner, Extra, Goals) :- length(AVs, N),
@@ -568,7 +698,8 @@ typed_functioncall_branch(Fun, TypeChain, T, GsH, IsPartial, Bound, Out, BranchG
     ( IsPartial -> append(Bound, AVsTmp0, AVsTmp) ; AVsTmp = AVsTmp0 ),
     append(GsH, GsT2, InnerTmp),
     ( (OutType == '%Undefined%' ; OutType == '_' ; OutType == 'Atom')
-       -> Extra = [] ; Extra = [('get-type'(Out, OutType) *-> true ; 'get-metatype'(Out, OutType))] ),
+       -> Extra = []
+       ; type_guard_goal(Out, OutType, OutGuard), Extra = [OutGuard] ),
     build_call_or_partial(Fun, AVsTmp, Out, InnerTmp, Extra, GoalsList),
     goals_list_to_conj(GoalsList, BranchGoal).
 
@@ -580,14 +711,15 @@ translate_args_by_type([A|As], [T|Ts], GsOut, [AV|AVs]) :-
                                            ; translate_expr(A, GsA1, AV),
                                              ( (T == '%Undefined%' ; T == '_')
                                                -> GsA = GsA1
-                                                ; append(GsA1, [('get-type'(AV, T) *-> true ; 'get-metatype'(AV, T))], GsA))),
+                                                ; type_guard_goal(AV, T, ArgGuard),
+                                                  append(GsA1, [ArgGuard], GsA))),
                                              translate_args_by_type(As, Ts, GsRest, AVs),
                                              append(GsA, GsRest, GsOut).
 
 %Handle data list:
 eval_data_term(X, [], X) :- (var(X); atomic(X)), !.
-eval_data_term([F|As], Goals, Val) :- ( atom(F), fun(F) -> translate_expr([F|As], Goals, Val)
-                                                         ; eval_data_list([F|As], Goals, Val) ).
+eval_data_term([F|As], Goals, Val) :- ( atom(F), callable_fun(F, _) -> translate_expr([F|As], Goals, Val)
+                                                                              ; eval_data_list([F|As], Goals, Val) ).
 
 %Handle data list entry:
 eval_data_list([], [], []).
@@ -642,6 +774,10 @@ build_hyperpose_branches([E|Es], [(Goal, Res)|Bs]) :- translate_expr_to_conj(E, 
                                                       build_hyperpose_branches(Es, Bs).
 
 %Runtime hyperpose path for variable/computed list arguments.
+space_hyperpose_runtime(Space, Exprs, Out) :- is_list(Exprs),
+                                              concurrent_and(member(Expr, Exprs),
+                                                             eval(Expr, Space, Out)).
+
 hyperpose_runtime(Exprs, Out) :- is_list(Exprs),
                                  concurrent_and(member(Expr, Exprs), eval(Expr, Out)).
 


### PR DESCRIPTION
Two weird behaviors detected:

1) Types adedd after a function may not apply to it
2) Space ownership of duplicate terms led to odd behavior (duplicates, seeming removal from space, etc).

See this program:
```
; Store the same equation under two independent owners.
!(bind! &foo (new-space))
!(add-atom &self (= (f) 1))
!(add-atom &foo (= (f) 1))

; Only &self contributes to default-context execution.
!(collapse (f))

; Remove only the copy owned by &foo.
!(remove-atom &foo (= (f) 1))

; Both &self's data and executable behavior remain intact.
!(match &self (= (f) $result) $result)
!(collapse (f))
```

PeTTa's old behavior: 
```
true
true
(1 1)
true
1
((f))
```

PeTTa's new behavior:
```
true
true
(1)
true
1
(1)
```

Codex and Claaude's solution is tog ive each space ownership of its compiled program, adding eval/2 for explicit context denotation (e.g., (eval $expr $space)), etc.

As to the actual PR, the edits are pretty extensive, so I might suggest using them as a reference for your own fix (if you agree with these semantics).

I think the coherent options are:
A) Something like this.
B) Something like MORK with one universal space.

The current version seems 'incoherent' (in weird cases).